### PR TITLE
For development purposes, suit envelope size check condition was chan…

### DIFF
--- a/src/suit.c
+++ b/src/suit.c
@@ -65,7 +65,9 @@ int suit_decode_envelope(uint8_t *envelope_str, size_t envelope_len,
 	ret = cbor_decode_SUIT_Envelope_Tagged(
 		envelope_str, envelope_len, &state->envelope, &decoded_len);
 
-	if ((ret != ZCBOR_SUCCESS) || (decoded_len != envelope_len)) {
+	/* For development, condition on expected envelope size was modified. 
+	   Now envelope_len represents max allowed size of envelope */
+	if ((ret != ZCBOR_SUCCESS) || (decoded_len > envelope_len)) {
 		state->envelope_decoded = suit_bool_false;
 		return ZCBOR_ERR_TO_SUIT_ERR(ret);
 	}


### PR DESCRIPTION
To ease up development while there is no way to pass envelope size to secdom, argument envelope_len passed to suit_decode_envelope is treated as max size of envelope rather than exact size.
This allows testing multiple different envelopes without padding to match hardcoded size.