### PR TITLE
cddl: Allow for envelopes without payloads

### DIFF
--- a/cddl/manifest.cddl
+++ b/cddl/manifest.cddl
@@ -28,7 +28,7 @@ SUIT_Envelope = {
   suit-authentication-wrapper => bstr .cbor SUIT_Authentication,
   suit-manifest  => bstr .cbor SUIT_Manifest,
   SUIT_Severable_Manifest_Members,
-  1*5 SUIT_Integrated_Payload,
+  0*5 SUIT_Integrated_Payload,
 ;  * $$SUIT_Envelope_Extensions,
 }
 


### PR DESCRIPTION
Once SUIT envelope is installed, all severable elements are removed. The SUIT processor must be able to parse such envelopes in order to implement SUIT-based boot.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>