### PR TITLE
NCSDK-22152: Add manifest representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ target_include_directories(manifest PUBLIC
 # Define SUIT library
 add_library(suit)
 target_sources(suit PRIVATE
+  src/suit_manifest.c
   src/suit_command_seq.c
   src/suit_seq_exec.c
   src/suit_condition.c

--- a/include/suit_manifest.h
+++ b/include/suit_manifest.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SUIT_MANIFEST_H__
+#define SUIT_MANIFEST_H__
+
+#include <suit_processor.h>
+
+/** @brief Assign and initialize the memory to store SUIT component parameters.
+ *
+ * @param[in] params  Reference to an array holding the component parameters values.
+ * @param[in] count   Size of the array.
+ *
+ * @returns SUIT_SUCCESS if the array was successfully initialized, error code otherwise.
+ */
+int suit_manifest_params_init(struct suit_manifest_params *params, size_t count);
+
+/** @brief Append a reference to a dependency manifest component to the manifest structure.
+ *
+ * @details This function will create a component only if the component with a given component_id
+ *          is not already created.
+ *
+ * @param[in] manifest      Manifest structure to modify.
+ * @param[in] component_id  ZCBOR string holding the component ID.
+ * @param[in] prefix        ZCBOR string holding the prefix to be used within the context of this manifest.
+ *                          Currently only an empty prefix is supported.
+ *
+ * @returns SUIT_SUCCESS if the dependency component was appended, error code otherwise.
+ */
+int suit_manifest_append_dependency(struct suit_manifest_state *manifest, struct zcbor_string *component_id, struct zcbor_string *prefix);
+
+/** @brief Append a reference to a regular component to the manifest structure.
+ *
+ * @details This function will create a component only if the component with a given component_id
+ *          is not already created.
+ *
+ * @param[in] manifest      Manifest structure to modify.
+ * @param[in] component_id  ZCBOR string holding the component ID.
+ *
+ * @returns SUIT_SUCCESS if the component was appended, error code otherwise.
+ */
+int suit_manifest_append_component(struct suit_manifest_state *manifest, struct zcbor_string *component_id);
+
+/** @brief Release all components, referenced by the manifest and reset the structure contents.
+ *
+ * @details This function will release a component through platform API only if the component
+ *          is not referenced by another manifest structure.
+ *
+ * @param[in] manifest  Manifest structure to release.
+ *
+ * @returns SUIT_SUCCESS if the manifest structure was reset, error code otherwise.
+ */
+int suit_manifest_release(struct suit_manifest_state *manifest);
+
+/** @brief Get the structure with SUIT component parameters for a given component index for a given manifest.
+ *
+ * @param[in]  manifest       Manifest structure, defining the context for the component index.
+ * @param[in]  component_idx  Component index in the manifest.
+ * @param[out] params         Reference to the structure with SUIT component parameters values.
+ *
+ * @returns SUIT_SUCCESS if the component was found and the structure was returned, error code otherwise.
+ */
+int suit_manifest_get_component_params(struct suit_manifest_state *manifest, size_t component_idx, struct suit_manifest_params **params);
+
+/** @brief Get the reference to the given command sequence for a given manifest.
+ *
+ * @details This function will return a command sequence only if it is marked as authenticated.
+ *
+ * @param[in] manifest  Manifest structure, defining the context for the command sequence.
+ * @param[in] seq_name  Name of the command sequence to return.
+ *
+ * @returns Reference to the command sequence if a valid, authenticated sequence was found, NULL pointer otherwise.
+ */
+struct zcbor_string *suit_manifest_get_command_seq(struct suit_manifest_state *manifest, enum suit_command_sequence seq_name);
+
+/** @brief Get the reference to an integrated payload with a given URI for a given manifest.
+ *
+ * @param[in]  manifest  Manifest structure, in which the URI is searched for.
+ * @param[in]  uri       URI of the integrated payload to find.
+ * @param[out] payload   Reference to the ZCBOR string holding the integrated payload.
+ *
+ * @returns SUIT_SUCCESS if the integrated payload was found and the structure was returned, error code otherwise.
+ */
+int suit_manifest_get_integrated_payload(struct suit_manifest_state *manifest, struct zcbor_string *uri, struct zcbor_string *payload);
+
+#endif /* SUIT_MANIFEST_H__ */

--- a/include/suit_processor.h
+++ b/include/suit_processor.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SUIT_PROCESSOR_H__
+#define SUIT_PROCESSOR_H__
+
+#include <suit_types.h>
+#include "manifest_types.h"
+
+
+enum suit_seq_status {
+	UNAVAILABLE,
+	SEVERED,
+	AUTHENTICATED,
+};
+
+struct suit_integrated_payload {
+	struct zcbor_string key;
+	struct zcbor_string payload;
+};
+
+struct suit_manifest_state {
+	struct zcbor_string envelope_str;
+	struct zcbor_string manifest_component_id;
+	uint32_t sequence_number;
+
+	struct suit_integrated_payload integrated_payloads[SUIT_MAX_NUM_INTEGRATED_PAYLOADS];
+	size_t integrated_payloads_count;
+
+	size_t component_map[SUIT_MAX_NUM_COMPONENTS];
+	size_t components_count;
+
+	struct zcbor_string shared_sequence;
+	enum suit_seq_status shared_sequence_status;
+
+	struct zcbor_string dependency_resolution_seq;
+	enum suit_seq_status dependency_resolution_seq_status;
+
+	struct zcbor_string payload_fetch_seq;
+	enum suit_seq_status payload_fetch_seq_status;
+
+	struct zcbor_string install_seq;
+	enum suit_seq_status install_seq_status;
+
+	struct zcbor_string validate_seq;
+	enum suit_seq_status validate_seq_status;
+
+	struct zcbor_string load_seq;
+	enum suit_seq_status load_seq_status;
+
+	struct zcbor_string invoke_seq;
+	enum suit_seq_status invoke_seq_status;
+
+	struct zcbor_string text;
+	enum suit_seq_status text_status;
+};
+
+#endif /* SUIT_PROCESSOR_H__ */

--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -15,11 +15,14 @@
 
 #define SUIT_MAX_NUM_SIGNERS 2  ///! The maximum number of signers.
 #define SUIT_MAX_NUM_COMPONENT_ID_PARTS 5  ///! The maximum number of bytestrings in a component ID.
-#define SUIT_MAX_NUM_COMPONENTS 4  ///! The maximum number of components referenced in the manifest.
+#define SUIT_MAX_NUM_COMPONENTS 6  ///! The maximum number of components referenced in the manifest.
+#define SUIT_MAX_NUM_COMPONENT_PARAMS (SUIT_MAX_NUM_COMPONENTS * SUIT_MAX_MANIFEST_DEPTH) ///! The maximum number of active components during processing dependency manifests.
+#define SUIT_MAX_NUM_INTEGRATED_PAYLOADS 5  ///! The maximum number of integrated payloads in a single manifest.
 #define SUIT_MAX_COMMAND_ARGS 3  ///! The maximum number of arguments consumed by a single command.
 #define SUIT_SUIT_SIG_STRUCTURE1_MAX_LENGTH 55  ///! The maximum length of the Sig_structure1 structure. Current value allows to store only 256-bit long digests.
 #define SUIT_MAX_SEQ_DEPTH 5  ///! The maximum number of command sequences that may be encapsulated.
 #define SUIT_SEQ_EXEC_DEFAULT_STATE 0  ///! The default value of the cmd_exec_state.
+#define SUIT_MAX_MANIFEST_DEPTH 3 ///! The maximum nesting level of hierarchical manifests.
 
 /** Errors from the suit API
  *
@@ -84,7 +87,9 @@ enum suit_bool {
 #define SUIT_NUM_STEPS 6
 
 enum suit_command_sequence {
+	SUIT_SEQ_INVALID,
 	SUIT_SEQ_PARSE,
+	SUIT_SEQ_SHARED,
 	SUIT_SEQ_DEP_RESOLUTION,
 	SUIT_SEQ_PAYLOAD_FETCH,
 	SUIT_SEQ_INSTALL,
@@ -107,10 +112,12 @@ enum suit_manifest_step {
 
 struct suit_manifest_params {
 	suit_component_t component_handle;
+	struct zcbor_string component_id;
+	uint_fast32_t ref_count;
 
 	struct zcbor_string vid;
 	struct zcbor_string cid;
-	struct SUIT_Digest image_digest;
+	struct zcbor_string image_digest;
 	size_t image_size;
 	unsigned int component_slot;
 	struct zcbor_string uri;
@@ -127,11 +134,15 @@ struct suit_manifest_params {
 	bool source_component_set;
 	bool invoke_args_set;
 	bool did_set;
+
+	enum suit_bool is_dependency;
+	bool integrity_checked;
 };
 
 static inline void suit_reset_params(struct suit_manifest_params *params)
 {
 	suit_component_t bak = params->component_handle;
+
 	memset(params, 0, sizeof(*params));
 	params->component_handle = bak;
 }
@@ -151,7 +162,7 @@ struct suit_seq_exec_state {
 	int cmd_exec_state; ///! Optional current command execution state.
 	enum suit_bool soft_failure; ///! suit-parameter-soft-failure
 	int retval; ///! Value returned by the nested command sequence execution.
-	const uint8_t * exec_ptr; ///! The pointer within the currently executed command sequence, pointing to the current command in the sequence.
+	const uint8_t *exec_ptr; ///! The pointer within the currently executed command sequence, pointing to the current command in the sequence.
 	size_t current_component_idx; ///! In case of nested command execution - the currently selected component from the component list.
 	bool current_components_backup[SUIT_MAX_NUM_COMPONENTS]; //! List of components, selected before the execution of command sequences.
 };
@@ -185,7 +196,7 @@ enum suit_cose_alg {
 };
 
 struct suit_arg {
-	union{struct zcbor_string *bstr; unsigned int uint;} arg;
+	union{struct zcbor_string *bstr; unsigned int uint; } arg;
 	enum{bstr, uint} arg_type;
 };
 

--- a/src/suit_condition.c
+++ b/src/suit_condition.c
@@ -93,13 +93,13 @@ int suit_condition_image_match(struct suit_processor_state *state,
 
 #ifdef SUIT_PLATFORM_LEGACY_API_SUPPORT
 	return suit_plat_check_image_match(suit_cose_sha256,
-			&component_params->image_digest._SUIT_Digest_suit_digest_bytes,
+			&component_params->image_digest,
 			component_params->image_size,
 			component_params->component_handle);
 #else /* SUIT_PLATFORM_LEGACY_API_SUPPORT */
 	return suit_plat_check_image_match(component_params->component_handle,
 			suit_cose_sha256,
-			&component_params->image_digest._SUIT_Digest_suit_digest_bytes,
+			&component_params->image_digest,
 			component_params->image_size);
 #endif /* SUIT_PLATFORM_LEGACY_API_SUPPORT */
 }

--- a/src/suit_directive.c
+++ b/src/suit_directive.c
@@ -198,7 +198,7 @@ static int set_param(struct suit_manifest_params *dst, struct SUIT_Parameters_ *
 		dst->cid_set = true;
 		break;
 	case _SUIT_Parameters_suit_parameter_image_digest:
-		memcpy(&dst->image_digest, &param->_SUIT_Parameters_suit_parameter_image_digest_cbor, sizeof(dst->image_digest));
+		memcpy(&dst->image_digest, &param->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes, sizeof(dst->image_digest));
 		dst->image_digest_set = true;
 		break;
 	case _SUIT_Parameters_suit_parameter_image_size:

--- a/src/suit_manifest.c
+++ b/src/suit_manifest.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <suit_manifest.h>
+#include <suit_processor.h>
+#include <suit_platform.h>
+
+static struct suit_manifest_params *components;
+static size_t components_count;
+
+
+static int assign_component_index(struct zcbor_string *component_id, size_t *assigned_index)
+{
+	int ret = SUIT_ERR_OVERFLOW;
+
+	for (size_t i = 0; i < components_count; i++) {
+		if ((components[i].ref_count != 0) &&
+		    (component_id->len == components[i].component_id.len) &&
+		    (memcmp(components[i].component_id.value, component_id->value, component_id->len) == 0)) {
+			SUIT_DBG("Found an existing component at index: %d\r\n", i);
+			*assigned_index = i;
+			components[i].ref_count++;
+			return SUIT_SUCCESS;
+		}
+	}
+
+	for (size_t i = 0; i < components_count; i++) {
+		if (components[i].ref_count == 0) {
+			SUIT_DBG("Creating a new component at index %d\r\n", i);
+			memset(&components[i], 0, sizeof(struct suit_manifest_params));
+			components[i].component_id = *component_id;
+			*assigned_index = i;
+
+#ifdef SUIT_PLATFORM_LEGACY_API_SUPPORT
+			ret = suit_plat_create_component_handle(component_id, NULL, 0, &components[i].component_handle);
+#else /* SUIT_PLATFORM_LEGACY_API_SUPPORT */
+			ret = suit_plat_create_component_handle(component_id, &components[i].component_handle);
+#endif /* SUIT_PLATFORM_LEGACY_API_SUPPORT */
+
+			if (ret == SUIT_SUCCESS) {
+				components[*assigned_index].ref_count++;
+			}
+			break;
+		}
+	}
+
+	return ret;
+}
+
+static int release_component_index(size_t assigned_index)
+{
+	int ret = SUIT_SUCCESS;
+
+	if ((assigned_index >= components_count) ||
+	    (components[assigned_index].ref_count == 0)) {
+		return SUIT_ERR_MISSING_COMPONENT;
+	}
+
+	if (components[assigned_index].ref_count == 1) {
+#ifndef SUIT_PLATFORM_LEGACY_API_SUPPORT
+		ret = suit_plat_release_component_handle(components[assigned_index].component_handle);
+		if (ret == SUIT_SUCCESS)
+#endif /* !SUIT_PLATFORM_LEGACY_API_SUPPORT */
+		{
+			components[assigned_index].is_dependency = 0;
+		}
+	}
+
+	if (ret == SUIT_SUCCESS) {
+		components[assigned_index].ref_count--;
+	}
+
+	return ret;
+}
+
+
+int suit_manifest_params_init(struct suit_manifest_params *params, size_t count)
+{
+	if ((params == NULL) || (count < 1)) {
+		SUIT_ERR("Invalid input parameters.\r\n");
+		return SUIT_ERR_CRASH;
+	}
+
+	if (components != NULL) {
+		SUIT_ERR("Module already initialized.\r\n");
+		return SUIT_ERR_ORDER;
+	}
+
+	components = params;
+	components_count = count;
+
+	memset(components, 0, sizeof(struct suit_manifest_params) * components_count);
+
+	return SUIT_SUCCESS;
+}
+
+int suit_manifest_append_dependency(struct suit_manifest_state *manifest, struct zcbor_string *component_id, struct zcbor_string *prefix)
+{
+	size_t index;
+
+	if ((components == NULL) || (components_count < 1)) {
+		SUIT_ERR("Module not initialized.\r\n");
+		return SUIT_ERR_ORDER;
+	}
+
+	if ((manifest == NULL) || (component_id == NULL) || (prefix == NULL)) {
+		SUIT_ERR("Invalid input parameters.\r\n");
+		return SUIT_ERR_CRASH;
+	}
+
+	if ((prefix->value != NULL) || (prefix->len != 0)) {
+		SUIT_ERR("Unsupported prefix value.\r\n");
+		return SUIT_ERR_MANIFEST_VALIDATION;
+	}
+
+	if (manifest->components_count >= ZCBOR_ARRAY_SIZE(manifest->component_map)) {
+		SUIT_ERR("Manifest reached the maximum number of components.\r\n");
+		return SUIT_ERR_MANIFEST_VALIDATION;
+	}
+
+	int ret = assign_component_index(component_id, &index);
+
+	if (ret == SUIT_SUCCESS) {
+		if (components[index].is_dependency == suit_bool_false) {
+			SUIT_ERR("The components is marked as dependency component, but a regular component was requested.\r\n");
+			ret = SUIT_ERR_MANIFEST_VALIDATION;
+			(void)release_component_index(index);
+		} else if (components[index].is_dependency != suit_bool_true) {
+			components[index].is_dependency = suit_bool_true;
+		}
+	}
+
+	if (ret == SUIT_SUCCESS) {
+		SUIT_DBG("Assigned index: %d for manifest component %d\r\n", index, manifest->components_count);
+		manifest->component_map[manifest->components_count] = index;
+		/* Increase the number of valid component indexes / handles */
+		manifest->components_count++;
+	} else {
+		SUIT_DBG("Failed to assign component index (%d)\r\n", ret);
+	}
+
+	return ret;
+}
+
+int suit_manifest_append_component(struct suit_manifest_state *manifest, struct zcbor_string *component_id)
+{
+	size_t index;
+
+	if ((components == NULL) || (components_count < 1)) {
+		SUIT_ERR("Module not initialized.\r\n");
+		return SUIT_ERR_ORDER;
+	}
+
+	if ((manifest == NULL) || (component_id == NULL)) {
+		SUIT_ERR("Invalid input parameters.\r\n");
+		return SUIT_ERR_CRASH;
+	}
+
+	if (manifest->components_count >= ZCBOR_ARRAY_SIZE(manifest->component_map)) {
+		SUIT_ERR("Manifest reached the maximum number of components.\r\n");
+		return SUIT_ERR_MANIFEST_VALIDATION;
+	}
+
+	int ret = assign_component_index(component_id, &index);
+
+	if (ret == SUIT_SUCCESS) {
+		if (components[index].is_dependency == suit_bool_true) {
+			SUIT_ERR("The components is marked as dependency component, but a regular component was requested.\r\n");
+			ret = SUIT_ERR_MANIFEST_VALIDATION;
+			(void)release_component_index(index);
+		} else if (components[index].is_dependency != suit_bool_false) {
+			components[index].is_dependency = suit_bool_false;
+		}
+	}
+
+	if (ret == SUIT_SUCCESS) {
+		SUIT_DBG("Assigned index: %d for manifest component %d\r\n", index, manifest->components_count);
+		manifest->component_map[manifest->components_count] = index;
+		/* Increase the number of valid component indexes / handles */
+		manifest->components_count++;
+	} else {
+		SUIT_DBG("Failed to assign component index (%d)\r\n", ret);
+	}
+
+	return ret;
+}
+
+int suit_manifest_release(struct suit_manifest_state *manifest)
+{
+	if ((components == NULL) || (components_count < 1)) {
+		SUIT_ERR("Module not initialized.\r\n");
+		return SUIT_ERR_ORDER;
+	}
+
+	if (manifest == NULL) {
+		SUIT_ERR("Invalid input parameters.\r\n");
+		return SUIT_ERR_CRASH;
+	}
+
+	for (int i = 0; i < manifest->components_count; i++) {
+		int ret = release_component_index(manifest->component_map[i]);
+
+		if (ret != SUIT_SUCCESS) {
+			return ret;
+		}
+	}
+
+#ifdef SUIT_PLATFORM_LEGACY_API_SUPPORT
+	suit_plat_reset_components();
+#endif /* SUIT_PLATFORM_LEGACY_API_SUPPORT */
+
+	memset(manifest, 0, sizeof(*manifest));
+
+	return SUIT_SUCCESS;
+}
+
+int suit_manifest_get_component_params(struct suit_manifest_state *manifest, size_t component_idx, struct suit_manifest_params **params)
+{
+	if ((components == NULL) || (components_count < 1)) {
+		SUIT_ERR("Module not initialized.\r\n");
+		return SUIT_ERR_ORDER;
+	}
+
+	if ((manifest == NULL) || (params == NULL)) {
+		SUIT_ERR("Invalid input parameters.\r\n");
+		return SUIT_ERR_CRASH;
+	}
+
+	if (component_idx >= manifest->components_count) {
+		return SUIT_ERR_MISSING_COMPONENT;
+	}
+
+	if (manifest->component_map[component_idx] >= components_count) {
+		return SUIT_ERR_MISSING_COMPONENT;
+	}
+
+	if (components[manifest->component_map[component_idx]].ref_count < 1) {
+		return SUIT_ERR_MISSING_COMPONENT;
+	}
+
+	*params = &components[manifest->component_map[component_idx]];
+
+	return SUIT_SUCCESS;
+}
+
+struct zcbor_string *suit_manifest_get_command_seq(struct suit_manifest_state *manifest, enum suit_command_sequence seq_name)
+{
+	if (manifest == NULL) {
+		return NULL;
+	}
+
+	switch (seq_name) {
+	case SUIT_SEQ_SHARED:
+		if (manifest->shared_sequence_status == AUTHENTICATED) {
+			return &manifest->shared_sequence;
+		}
+		return NULL;
+	case SUIT_SEQ_PAYLOAD_FETCH:
+		if (manifest->payload_fetch_seq_status == AUTHENTICATED) {
+			return &manifest->payload_fetch_seq;
+		}
+		return NULL;
+	case SUIT_SEQ_INSTALL:
+		if (manifest->install_seq_status == AUTHENTICATED) {
+			return &manifest->install_seq;
+		}
+		return NULL;
+	case SUIT_SEQ_VALIDATE:
+		if (manifest->validate_seq_status == AUTHENTICATED) {
+			return &manifest->validate_seq;
+		}
+		return NULL;
+	case SUIT_SEQ_LOAD:
+		if (manifest->load_seq_status == AUTHENTICATED) {
+			return &manifest->load_seq;
+		}
+		return NULL;
+	case SUIT_SEQ_INVOKE:
+		if (manifest->invoke_seq_status == AUTHENTICATED) {
+			return &manifest->invoke_seq;
+		}
+		return NULL;
+	default:
+		return NULL;
+	}
+
+	return NULL;
+}
+
+int suit_manifest_get_integrated_payload(struct suit_manifest_state *manifest, struct zcbor_string *uri, struct zcbor_string *payload)
+{
+	if ((uri == NULL) || (manifest == NULL) || (payload == NULL)) {
+		SUIT_ERR("Invalid input parameters.\r\n");
+		return SUIT_ERR_CRASH;
+	}
+
+	for (int i = 0; i < manifest->integrated_payloads_count; i++) {
+		if (suit_compare_zcbor_strings(&manifest->integrated_payloads[i].key, uri)) {
+			*payload = manifest->integrated_payloads[i].payload;
+			return SUIT_SUCCESS;
+		}
+	}
+
+	return SUIT_ERR_UNAVAILABLE_PAYLOAD;
+}

--- a/tests/unit/manifest/CMakeLists.txt
+++ b/tests/unit/manifest/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(unit_test_manifest)
+include(../../cmake/test_template.cmake)
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../common" "${PROJECT_BINARY_DIR}/test_common")
+
+# generate runner for the test
+test_runner_generate(src/main.c)
+
+# create mocks for suit_platform functions
+cmock_handle(${SUIT_PROCESSOR_DIR}/include/suit_platform.h suit_platform)
+
+target_link_libraries(app PRIVATE zephyr_interface)

--- a/tests/unit/manifest/prj.conf
+++ b/tests/unit/manifest/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_UNITY=y
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_NO_OPTIMIZATIONS=y

--- a/tests/unit/manifest/src/main.c
+++ b/tests/unit/manifest/src/main.c
@@ -1,0 +1,977 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <unity.h>
+#include <stdint.h>
+#include <suit_processor.h>
+#include <suit_manifest.h>
+#include "suit_platform/cmock_suit_platform.h"
+
+static struct suit_manifest_params components[SUIT_MAX_NUM_COMPONENT_PARAMS];
+
+void uninitialized_append_component(void);
+void uninitialized_append_dependency(void);
+void uninitialized_release(void);
+void uninitialized_get_component_params(void);
+
+void setUp(void)
+{
+	int ret = SUIT_SUCCESS;
+	static bool initialized = false;
+
+	if (!initialized) {
+		uninitialized_append_component();
+		uninitialized_append_dependency();
+		uninitialized_release();
+		uninitialized_get_component_params();
+
+		ret = suit_manifest_params_init((struct suit_manifest_params *)&components, ZCBOR_ARRAY_SIZE(components));
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to initialize SUIT manifest parameters");
+
+		initialized = true;
+	} else {
+		ret = suit_manifest_params_init((struct suit_manifest_params *)&components, ZCBOR_ARRAY_SIZE(components));
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_ORDER, ret, "Unable to initialize SUIT manifest parameters");
+		memset(components, 0, sizeof(components));
+	}
+
+	/* Just to be sure that the macro returns the correct value. */
+	TEST_ASSERT_EQUAL_MESSAGE(ZCBOR_ARRAY_SIZE(components), SUIT_MAX_NUM_COMPONENT_PARAMS, "The number of component parameters entries does not match");
+}
+
+void test_params_init_invalid_input(void)
+{
+	int ret = SUIT_SUCCESS;
+
+	ret = suit_manifest_params_init(NULL, SUIT_MAX_NUM_COMPONENTS);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Initialization with NULL pointer returned unexpected value");
+
+	ret = suit_manifest_params_init((struct suit_manifest_params *)&components, 0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Initialization with too small memory returned unexpected value");
+
+	ret = suit_manifest_params_init((struct suit_manifest_params *)&components, SUIT_MAX_NUM_COMPONENTS);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_ORDER, ret, "Initialization of already initialized module returned unexpected value");
+}
+
+void uninitialized_append_component(void)
+{
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	int ret = suit_manifest_append_component(&manifest, &sample_component_0);
+
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_ORDER, ret, "A component was appended on uninitialized module");
+}
+
+void test_append_component_invalid_input(void)
+{
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	ret = suit_manifest_append_component(NULL, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "A component was appended to NULL manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+
+	ret = suit_manifest_append_component(&manifest, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "A NULL component was appended to manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+}
+
+void test_append_component_invalid_state(void)
+{
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	/* Create an invalid component inside the database. */
+	components[0].component_handle = 0;
+	components[0].is_dependency = suit_bool_true;
+	components[0].ref_count = 1;
+	components[0].component_id = sample_component_0;
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "A component with invalid dependency flag was added");
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(suit_bool_true, components[0].is_dependency, "Unexpected value of component dependency flag");
+}
+
+void test_append_component_unsupported_id(void)
+{
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_ERR_UNSUPPORTED_COMPONENT_ID);
+	__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_UNSUPPORTED_COMPONENT_ID, ret, "An unsupported component was added");
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[0].ref_count, "Unexpected value of the reference counter");
+}
+
+void test_append_component_fill_array(void)
+{
+	suit_component_t component_handle;
+	struct suit_manifest_state manifest;
+	struct suit_manifest_state sub_manifest;
+	int ret = SUIT_SUCCESS;
+
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+
+	/* Initialize the sub_manifest structure. */
+	memset(&sub_manifest, 0, sizeof(sub_manifest));
+	sub_manifest.components_count = 0;
+
+	/* Initialize the sample component ID.
+	 * The remaining component IDs will be created by changing the length of the static string.
+	 */
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0123456789abcdef67890",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	/* Verify that the test boundaries can be reached. */
+	TEST_ASSERT_LESS_THAN_MESSAGE(
+		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		SUIT_MAX_NUM_COMPONENTS,
+		"Unable to reach maximum number of components. Please extend the component ID generator"
+	);
+
+	TEST_ASSERT_LESS_THAN_MESSAGE(
+		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		SUIT_MAX_NUM_COMPONENT_PARAMS,
+		"Unable to reach maximum number of components. Please extend the component ID generator"
+	);
+
+	/* Fill the component array. */
+	for (size_t i = 0; i < SUIT_MAX_NUM_COMPONENTS; i++) {
+		component_handle = i;
+		sample_component_0.len = strlen("TEST_COMPONENT_0") + i;
+
+		__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+		__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+		__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+		ret = suit_manifest_append_component(&manifest, &sample_component_0);
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+		/* Verify the component mapping. */
+		TEST_ASSERT_EQUAL_MESSAGE(i + 1, manifest.components_count, "The manifest component counter was not increased");
+		TEST_ASSERT_EQUAL_MESSAGE(i, manifest.component_map[i], "Unexpected value of the component mapping");
+
+		/* Verify the contents of the created component. */
+		TEST_ASSERT_EQUAL_MESSAGE(component_handle, components[i].component_handle, "Unexpected value of the component handle");
+		TEST_ASSERT_EQUAL_MESSAGE(1, components[i].ref_count, "Unexpected value of the reference counter");
+		TEST_ASSERT_EQUAL_MESSAGE(sample_component_0.value, components[i].component_id.value, "Unexpected value of component ID value");
+		TEST_ASSERT_EQUAL_MESSAGE(strlen("TEST_COMPONENT_0") + i, components[i].component_id.len, "Unexpected value of component ID length");
+		TEST_ASSERT_EQUAL_MESSAGE(suit_bool_false, components[i].is_dependency, "Unexpected value of component dependency flag");
+		TEST_ASSERT_EQUAL_MESSAGE(false, components[i].integrity_checked, "Invalid initial value of the integrity flag");
+	}
+
+	/* Verify that the manifest component array is full. */
+	component_handle = SUIT_MAX_NUM_COMPONENTS;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + SUIT_MAX_NUM_COMPONENTS;
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the new component was added");
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the new component was added");
+
+	component_handle = 0;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 0;
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the existing component was added");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter after failed component addition");
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the existing component was added");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter after failed component addition");
+
+	/* Fill half of the array with the same IDs, using the second manifest,
+	 * so that should result in the increased reference counters.
+	 */
+	for (size_t i = 0; i < (SUIT_MAX_NUM_COMPONENTS / 2); i++) {
+		component_handle = i;
+		sample_component_0.len = strlen("TEST_COMPONENT_0") + i;
+
+		ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append an existing component to submanifest");
+
+		/* Verify the component mapping. */
+		TEST_ASSERT_EQUAL_MESSAGE(i + 1, sub_manifest.components_count, "The manifest component counter was not increased");
+		TEST_ASSERT_EQUAL_MESSAGE(i, sub_manifest.component_map[i], "Unexpected value of the component mapping");
+
+		/* Verify the contents of the created component. */
+		TEST_ASSERT_EQUAL_MESSAGE(component_handle, components[i].component_handle, "Unexpected value of the component handle");
+		TEST_ASSERT_EQUAL_MESSAGE(2, components[i].ref_count, "Unexpected value of the reference counter");
+		TEST_ASSERT_EQUAL_MESSAGE(sample_component_0.value, components[i].component_id.value, "Unexpected value of component ID value");
+		TEST_ASSERT_EQUAL_MESSAGE(strlen("TEST_COMPONENT_0") + i, components[i].component_id.len, "Unexpected value of component ID length");
+		TEST_ASSERT_EQUAL_MESSAGE(suit_bool_false, components[i].is_dependency, "Unexpected value of component dependency flag");
+		TEST_ASSERT_EQUAL_MESSAGE(false, components[i].integrity_checked, "Invalid initial value of the integrity flag");
+	}
+
+	/* Reach the boundaries of component params storage using single, flakey slot of the submanifest. */
+	for (size_t i = SUIT_MAX_NUM_COMPONENTS; i < SUIT_MAX_NUM_COMPONENT_PARAMS; i++) {
+		component_handle = i;
+		sample_component_0.len = strlen("TEST_COMPONENT_0") + i;
+
+		__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+		__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+		__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+		ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component to submanifest");
+
+		/* Verify the component mapping. */
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_MAX_NUM_COMPONENTS / 2 + 1, sub_manifest.components_count, "The manifest component counter was not increased");
+		TEST_ASSERT_EQUAL_MESSAGE(i, sub_manifest.component_map[sub_manifest.components_count - 1], "Unexpected value of the component mapping");
+
+		/* Verify the contents of the created component. */
+		TEST_ASSERT_EQUAL_MESSAGE(component_handle, components[i].component_handle, "Unexpected value of the component handle");
+		TEST_ASSERT_EQUAL_MESSAGE(1, components[i].ref_count, "Unexpected value of the reference counter");
+		TEST_ASSERT_EQUAL_MESSAGE(sample_component_0.value, components[i].component_id.value, "Unexpected value of component ID value");
+		TEST_ASSERT_EQUAL_MESSAGE(strlen("TEST_COMPONENT_0") + i, components[i].component_id.len, "Unexpected value of component ID length");
+		TEST_ASSERT_EQUAL_MESSAGE(suit_bool_false, components[i].is_dependency, "Unexpected value of component dependency flag");
+		TEST_ASSERT_EQUAL_MESSAGE(false, components[i].integrity_checked, "Invalid initial value of the integrity flag");
+
+		/* Hack the last entry of manifest mapping to use it once again. */
+		sub_manifest.components_count--;
+	}
+
+	/* Verify that the component parameters array is full. */
+	component_handle = SUIT_MAX_NUM_COMPONENT_PARAMS;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + SUIT_MAX_NUM_COMPONENT_PARAMS;
+
+	ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_OVERFLOW, ret, "Parameters capacity reached, but a new component was added");
+
+	ret = suit_manifest_append_dependency(&sub_manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_OVERFLOW, ret, "Parameters capacity reached, but a new component was added");
+
+	/* Verify that it is still possible to assign existing components to manifests. */
+	for (size_t i = (SUIT_MAX_NUM_COMPONENTS / 2); i < SUIT_MAX_NUM_COMPONENTS; i++) {
+		component_handle = i;
+		sample_component_0.len = strlen("TEST_COMPONENT_0") + i;
+
+		TEST_ASSERT_EQUAL_MESSAGE(1, components[i].ref_count, "Unexpected value of the reference counter");
+
+		ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append an existing component to submanifest");
+
+		/* Verify the component mapping. */
+		TEST_ASSERT_EQUAL_MESSAGE(i + 1, sub_manifest.components_count, "The manifest component counter was not increased");
+		TEST_ASSERT_EQUAL_MESSAGE(i, sub_manifest.component_map[i], "Unexpected value of the component mapping");
+
+		/* Verify the contents of the created component. */
+		TEST_ASSERT_EQUAL_MESSAGE(component_handle, components[i].component_handle, "Unexpected value of the component handle");
+		TEST_ASSERT_EQUAL_MESSAGE(2, components[i].ref_count, "Unexpected value of the reference counter");
+		TEST_ASSERT_EQUAL_MESSAGE(sample_component_0.value, components[i].component_id.value, "Unexpected value of component ID value");
+		TEST_ASSERT_EQUAL_MESSAGE(strlen("TEST_COMPONENT_0") + i, components[i].component_id.len, "Unexpected value of component ID length");
+		TEST_ASSERT_EQUAL_MESSAGE(suit_bool_false, components[i].is_dependency, "Unexpected value of component dependency flag");
+		TEST_ASSERT_EQUAL_MESSAGE(false, components[i].integrity_checked, "Invalid initial value of the integrity flag");
+	}
+
+	/* Verify that the both arrays are full. */
+	component_handle = SUIT_MAX_NUM_COMPONENTS;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + SUIT_MAX_NUM_COMPONENTS;
+
+	ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the new component was added");
+
+	component_handle = 0;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 0;
+
+	ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the existing component was added");
+	TEST_ASSERT_EQUAL_MESSAGE(2, components[0].ref_count, "Unexpected value of the reference counter after failed component addition");
+}
+
+void uninitialized_append_dependency(void)
+{
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	int ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_ORDER, ret, "A dependency was appended on uninitialized module");
+}
+
+void test_append_dependency_invalid_input(void)
+{
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	ret = suit_manifest_append_dependency(NULL, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "A dependency was appended to NULL manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+
+	ret = suit_manifest_append_dependency(&manifest, NULL, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "A NULL component was appended to manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "A NULL prefix was appended to manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "A dependency with non-empty prefix was appended to manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+
+	prefix.value = sample_component_0.value;
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "A dependency with non-empty prefix was appended to manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+
+	prefix.value = NULL;
+	prefix.len = sample_component_0.len;
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "A dependency with non-empty prefix was appended to manifest");
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+}
+
+void test_append_dependency_invalid_state(void)
+{
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	/* Create an invalid component inside the database. */
+	components[0].component_handle = 0;
+	components[0].is_dependency = suit_bool_false;
+	components[0].ref_count = 1;
+	components[0].component_id = sample_component_0;
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "A component with invalid dependency flag was added");
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(suit_bool_false, components[0].is_dependency, "Unexpected value of component dependency flag");
+}
+
+void test_append_dependency_unsupported_id(void)
+{
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_ERR_UNSUPPORTED_COMPONENT_ID);
+	__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_UNSUPPORTED_COMPONENT_ID, ret, "An unsupported component was added");
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, manifest.components_count, "The manifest component counter was increased");
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[0].ref_count, "Unexpected value of the reference counter");
+}
+
+void test_append_dependency_fill_array(void)
+{
+	suit_component_t component_handle;
+	struct suit_manifest_state manifest;
+	int ret = SUIT_SUCCESS;
+
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+
+	/* Initialize the sample component ID.
+	 * The remaining component IDs will be created by changing the length of the static string.
+	 */
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0123456789abcdef67890",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	/* Verify that the test boundaries can be reached. */
+	TEST_ASSERT_LESS_THAN_MESSAGE(
+		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		SUIT_MAX_NUM_COMPONENTS,
+		"Unable to reach maximum number of components. Please extend the component ID generator"
+	);
+
+	TEST_ASSERT_LESS_THAN_MESSAGE(
+		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		SUIT_MAX_NUM_COMPONENT_PARAMS,
+		"Unable to reach maximum number of components. Please extend the component ID generator"
+	);
+
+	/* Fill the component array. */
+	for (size_t i = 0; i < SUIT_MAX_NUM_COMPONENTS; i++) {
+		component_handle = i;
+		sample_component_0.len = strlen("TEST_COMPONENT_0") + i;
+
+		__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+		__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+		__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+		ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+		TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+		/* Verify the component mapping. */
+		TEST_ASSERT_EQUAL_MESSAGE(i + 1, manifest.components_count, "The manifest component counter was not increased");
+		TEST_ASSERT_EQUAL_MESSAGE(i, manifest.component_map[i], "Unexpected value of the component mapping");
+
+		/* Verify the contents of the created component. */
+		TEST_ASSERT_EQUAL_MESSAGE(component_handle, components[i].component_handle, "Unexpected value of the component handle");
+		TEST_ASSERT_EQUAL_MESSAGE(1, components[i].ref_count, "Unexpected value of the reference counter");
+		TEST_ASSERT_EQUAL_MESSAGE(sample_component_0.value, components[i].component_id.value, "Unexpected value of component ID value");
+		TEST_ASSERT_EQUAL_MESSAGE(strlen("TEST_COMPONENT_0") + i, components[i].component_id.len, "Unexpected value of component ID length");
+		TEST_ASSERT_EQUAL_MESSAGE(suit_bool_true, components[i].is_dependency, "Unexpected value of component dependency flag");
+		TEST_ASSERT_EQUAL_MESSAGE(false, components[i].integrity_checked, "Invalid initial value of the integrity flag");
+	}
+
+	/* Verify that the manifest component array is full. */
+	component_handle = SUIT_MAX_NUM_COMPONENTS;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + SUIT_MAX_NUM_COMPONENTS;
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the new component was added");
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the new component was added");
+
+	component_handle = 0;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 0;
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the existing component was added");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter after failed component addition");
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MANIFEST_VALIDATION, ret, "Manifest capacity reached, but the existing component was added");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter after failed component addition");
+}
+
+void uninitialized_release(void)
+{
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+
+	int ret = suit_manifest_release(&manifest);
+
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_ORDER, ret, "A manifest was released on uninitialized module");
+}
+
+void test_release_invalid_input(void)
+{
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+
+	int ret = suit_manifest_release(NULL);
+
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "A NULL manifest was released");
+}
+
+void test_release_invalid_state(void)
+{
+	int ret = SUIT_SUCCESS;
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+
+	/* Map a component with cleared reference counter. */
+	manifest.components_count = 1;
+	manifest.component_map[0] = 0;
+
+	ret = suit_manifest_release(&manifest);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MISSING_COMPONENT, ret, "An uninitialized component was released");
+	TEST_ASSERT_EQUAL_MESSAGE(1, manifest.components_count, "The manifest component counter was decreased");
+
+	/* Map a component outside of the parameters boundaries. */
+	manifest.components_count = 1;
+	manifest.component_map[0] = SUIT_MAX_NUM_COMPONENT_PARAMS;
+
+	ret = suit_manifest_release(&manifest);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MISSING_COMPONENT, ret, "An out of range component was released");
+	TEST_ASSERT_EQUAL_MESSAGE(1, manifest.components_count, "The manifest component counter was decreased");
+
+	/* Fail to release the component on the platform level. */
+	components[0].ref_count = 1;
+	components[0].component_handle = 123;
+	components[0].is_dependency = suit_bool_false;
+	manifest.components_count = 1;
+	manifest.component_map[0] = 0;
+
+	__cmock_suit_plat_release_component_handle_ExpectAndReturn(123, SUIT_ERR_UNSUPPORTED_COMPONENT_ID);
+
+	ret = suit_manifest_release(&manifest);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_UNSUPPORTED_COMPONENT_ID, ret, "The platfrom-level failure was not propagated");
+	TEST_ASSERT_EQUAL_MESSAGE(1, manifest.components_count, "The manifest component counter was decreased");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "The component reference counter was decreased");
+	TEST_ASSERT_EQUAL_MESSAGE(suit_bool_false, components[0].is_dependency, "The dependency flag was altered");
+}
+
+void test_release_appended_components(void)
+{
+	suit_component_t component_handle;
+	struct suit_manifest_state manifest;
+	struct suit_manifest_state sub_manifest;
+	int ret = SUIT_SUCCESS;
+
+	static struct zcbor_string prefix = {
+		.value = NULL,
+		.len = 0,
+	};
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 0;
+
+	/* Initialize the sub_manifest structure. */
+	memset(&sub_manifest, 0, sizeof(sub_manifest));
+	sub_manifest.components_count = 0;
+
+	/* Initialize the sample component ID.
+	 * The remaining component IDs will be created by changing the length of the static string.
+	 */
+	static struct zcbor_string sample_component_0 = {
+		.value = "TEST_COMPONENT_0123",
+		.len = sizeof("TEST_COMPONENT_0"),
+	};
+
+	/* Create components */
+	component_handle = 0;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 0;
+
+	__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+	__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+	component_handle = 1;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 1;
+
+	__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+	__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+	ret = suit_manifest_append_component(&manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+	ret = suit_manifest_append_component(&sub_manifest, &sample_component_0);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+	component_handle = 2;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 2;
+
+	__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+	__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+	ret = suit_manifest_append_dependency(&sub_manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+	ret = suit_manifest_append_dependency(&manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+	component_handle = 3;
+	sample_component_0.len = strlen("TEST_COMPONENT_0") + 3;
+
+	__cmock_suit_plat_create_component_handle_ExpectAndReturn(&sample_component_0, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_create_component_handle_IgnoreArg_handle();
+	__cmock_suit_plat_create_component_handle_ReturnThruPtr_handle(&component_handle);
+
+	ret = suit_manifest_append_dependency(&sub_manifest, &sample_component_0, &prefix);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to append a new component");
+
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[0].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(2, components[1].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(2, components[2].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[3].ref_count, "Unexpected value of the reference counter");
+
+	/* Release the first manifest. */
+	__cmock_suit_plat_release_component_handle_ExpectAndReturn(0, SUIT_SUCCESS);
+
+	ret = suit_manifest_release(&manifest);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to release manifest");
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[0].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[1].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[2].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(1, components[3].ref_count, "Unexpected value of the reference counter");
+
+	/* Release the second manifest. */
+	__cmock_suit_plat_release_component_handle_ExpectAndReturn(1, SUIT_SUCCESS);
+	__cmock_suit_plat_release_component_handle_ExpectAndReturn(2, SUIT_SUCCESS);
+	__cmock_suit_plat_release_component_handle_ExpectAndReturn(3, SUIT_SUCCESS);
+
+	ret = suit_manifest_release(&sub_manifest);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to release manifest");
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[0].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[1].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[2].ref_count, "Unexpected value of the reference counter");
+	TEST_ASSERT_EQUAL_MESSAGE(0, components[3].ref_count, "Unexpected value of the reference counter");
+}
+
+void uninitialized_get_component_params(void)
+{
+	struct suit_manifest_params *params;
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 1;
+	manifest.component_map[0] = 0;
+	components[0].ref_count = 1;
+	components[0].component_handle = 123;
+
+	int ret = suit_manifest_get_component_params(&manifest, 0, &params);
+
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_ORDER, ret, "Parameters returned on uninitialized module");
+}
+
+void test_get_component_params(void)
+{
+	int ret = SUIT_SUCCESS;
+	struct suit_manifest_params *params;
+	struct suit_manifest_state manifest;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.components_count = 1;
+	manifest.component_map[0] = 0;
+	components[0].ref_count = 1;
+	components[0].component_handle = 123;
+
+	ret = suit_manifest_get_component_params(NULL, 0, &params);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Parameters returned for NULL manifest");
+
+	ret = suit_manifest_get_component_params(&manifest, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Parameters returned to NULL pointer");
+
+	ret = suit_manifest_get_component_params(&manifest, SUIT_MAX_NUM_COMPONENTS, &params);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MISSING_COMPONENT, ret, "Parameters returned for out-of-range component");
+
+	manifest.component_map[0] = SUIT_MAX_NUM_COMPONENT_PARAMS;
+	ret = suit_manifest_get_component_params(&manifest, 0, &params);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MISSING_COMPONENT, ret, "Parameters returned for out-of-range component");
+
+	manifest.component_map[0] = 1;
+	ret = suit_manifest_get_component_params(&manifest, 0, &params);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_MISSING_COMPONENT, ret, "Parameters returned for non-referenced component");
+
+	manifest.component_map[0] = 0;
+	ret = suit_manifest_get_component_params(&manifest, 0, &params);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to get component parameters");
+	TEST_ASSERT_EQUAL_MESSAGE(params, &components[0], "Invalid reference to component parameters returned");
+}
+
+void test_get_command_seq_invalid_input(void)
+{
+	struct zcbor_string *seq;
+
+	enum suit_command_sequence seq_name;
+
+	for (seq_name = SUIT_SEQ_INVALID; seq_name <= SUIT_SEQ_MAX; seq_name++) {
+		seq = suit_manifest_get_command_seq(NULL, seq_name);
+		TEST_ASSERT_EQUAL_MESSAGE(NULL, seq, "Sequence returned for a NULL manifest");
+	}
+}
+
+void test_get_command_seq_empty_manifest(void)
+{
+	struct suit_manifest_state manifest;
+	struct zcbor_string *seq;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+
+	enum suit_command_sequence seq_name;
+
+	for (seq_name = SUIT_SEQ_INVALID; seq_name <= SUIT_SEQ_MAX; seq_name++) {
+		seq = suit_manifest_get_command_seq(&manifest, seq_name);
+		TEST_ASSERT_EQUAL_MESSAGE(NULL, seq, "Sequence returned for an empty manifest");
+	}
+}
+
+void test_get_command_seq_unavailable(void)
+{
+	struct suit_manifest_state manifest;
+	struct zcbor_string *seq;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.shared_sequence_status = UNAVAILABLE;
+	manifest.payload_fetch_seq_status = UNAVAILABLE;
+	manifest.install_seq_status = UNAVAILABLE;
+	manifest.validate_seq_status = UNAVAILABLE;
+	manifest.load_seq_status = UNAVAILABLE;
+	manifest.invoke_seq_status = UNAVAILABLE;
+
+	enum suit_command_sequence seq_name;
+
+	for (seq_name = SUIT_SEQ_INVALID; seq_name <= SUIT_SEQ_MAX; seq_name++) {
+		seq = suit_manifest_get_command_seq(&manifest, seq_name);
+		TEST_ASSERT_EQUAL_MESSAGE(NULL, seq, "Unavailable sequence returned");
+	}
+}
+
+void test_get_command_seq_severed(void)
+{
+	struct suit_manifest_state manifest;
+	struct zcbor_string *seq;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.shared_sequence_status = SEVERED;
+	manifest.payload_fetch_seq_status = SEVERED;
+	manifest.install_seq_status = SEVERED;
+	manifest.validate_seq_status = SEVERED;
+	manifest.load_seq_status = SEVERED;
+	manifest.invoke_seq_status = SEVERED;
+
+	enum suit_command_sequence seq_name;
+
+	for (seq_name = SUIT_SEQ_INVALID; seq_name <= SUIT_SEQ_MAX; seq_name++) {
+		seq = suit_manifest_get_command_seq(&manifest, seq_name);
+		TEST_ASSERT_EQUAL_MESSAGE(NULL, seq, "Severed sequence returned");
+	}
+}
+
+void test_get_command_seq_authenticated(void)
+{
+	struct suit_manifest_state manifest;
+	struct zcbor_string *seq;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.shared_sequence_status = AUTHENTICATED;
+	manifest.payload_fetch_seq_status = AUTHENTICATED;
+	manifest.install_seq_status = AUTHENTICATED;
+	manifest.validate_seq_status = AUTHENTICATED;
+	manifest.load_seq_status = AUTHENTICATED;
+	manifest.invoke_seq_status = AUTHENTICATED;
+
+	enum suit_command_sequence seq_name;
+
+	for (seq_name = SUIT_SEQ_INVALID; seq_name <= SUIT_SEQ_MAX; seq_name++) {
+		struct zcbor_string *exp_seq = NULL;
+
+		switch (seq_name) {
+		case SUIT_SEQ_SHARED:
+			exp_seq = &manifest.shared_sequence;
+			break;
+		case SUIT_SEQ_PAYLOAD_FETCH:
+			exp_seq = &manifest.payload_fetch_seq;
+			break;
+		case SUIT_SEQ_INSTALL:
+			exp_seq = &manifest.install_seq;
+			break;
+		case SUIT_SEQ_VALIDATE:
+			exp_seq = &manifest.validate_seq;
+			break;
+		case SUIT_SEQ_LOAD:
+			exp_seq = &manifest.load_seq;
+			break;
+		case SUIT_SEQ_INVOKE:
+			exp_seq = &manifest.invoke_seq;
+			break;
+		default:
+			break;
+		}
+
+		seq = suit_manifest_get_command_seq(&manifest, seq_name);
+		TEST_ASSERT_EQUAL_MESSAGE(exp_seq, seq, "Invalid sequence returned");
+	}
+}
+
+void test_get_integrated_payload_invalid_input(void)
+{
+	struct suit_manifest_state manifest;
+	struct zcbor_string uri = {
+		.value = "http://example.com",
+		.len = strlen("http://example.com"),
+	};
+	struct zcbor_string payload;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.integrated_payloads_count = 0;
+
+	ret = suit_manifest_get_integrated_payload(NULL, &uri, &payload);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Payload returned from NULL manifest");
+
+	ret = suit_manifest_get_integrated_payload(&manifest, NULL, &payload);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Payload returned from NULL URI");
+
+	ret = suit_manifest_get_integrated_payload(&manifest, &uri, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_CRASH, ret, "Payload returned from NULL payload");
+
+	ret = suit_manifest_get_integrated_payload(&manifest, &uri, &payload);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_UNAVAILABLE_PAYLOAD, ret, "Payload returned from empty manifest");
+}
+
+void test_get_integrated_payload_nonempty_uri(void)
+{
+	struct suit_manifest_state manifest;
+	struct zcbor_string uri_0 = {
+		.value = "http://example.com",
+		.len = strlen("http://example.com"),
+	};
+	struct zcbor_string uri_1 = {
+		.value = "http://sample.com",
+		.len = strlen("http://sample.com"),
+	};
+	struct zcbor_string uri_2 = {
+		.value = "#app.bin",
+		.len = strlen("#app.bin"),
+	};
+	struct zcbor_string payload_0 = {
+		.value = "CAFECAFE",
+		.len = sizeof("CAFECAFE"),
+	};
+	struct zcbor_string payload_1 = {
+		.value = "ABCD",
+		.len = sizeof("ABCD"),
+	};
+	struct zcbor_string payload_2 = {
+		.value = "This is a sample FW file",
+		.len = sizeof("This is a sample FW file"),
+	};
+	struct zcbor_string payload;
+	int ret = SUIT_SUCCESS;
+
+	/* Initialize the manifest structure. */
+	memset(&manifest, 0, sizeof(manifest));
+	manifest.integrated_payloads[0].key = uri_0;
+	manifest.integrated_payloads[1].key = uri_1;
+	manifest.integrated_payloads[2].key = uri_2;
+	manifest.integrated_payloads[0].payload = payload_0;
+	manifest.integrated_payloads[1].payload = payload_1;
+	manifest.integrated_payloads[2].payload = payload_2;
+	manifest.integrated_payloads_count = 2;
+
+	ret = suit_manifest_get_integrated_payload(&manifest, &uri_0, &payload);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to get integrated payload");
+	TEST_ASSERT_EQUAL_MESSAGE(payload_0.value, payload.value, "Unexpected value of payload contents");
+	TEST_ASSERT_EQUAL_MESSAGE(payload_0.len, payload.len, "Unexpected value of payload length");
+
+	ret = suit_manifest_get_integrated_payload(&manifest, &uri_2, &payload);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_ERR_UNAVAILABLE_PAYLOAD, ret, "Out-of-range payload returned");
+
+	ret = suit_manifest_get_integrated_payload(&manifest, &uri_1, &payload);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "Unable to get integrated payload");
+	TEST_ASSERT_EQUAL_MESSAGE(payload_1.value, payload.value, "Unexpected value of payload contents");
+	TEST_ASSERT_EQUAL_MESSAGE(payload_1.len, payload.len, "Unexpected value of payload length");
+}
+
+
+/* It is required to be added to each test. That is because unity's
+ * main may return nonzero, while zephyr's main currently must
+ * return 0 in all cases (other values are reserved).
+ */
+extern int unity_main(void);
+
+int main(void)
+{
+	(void)unity_main();
+
+	return 0;
+}

--- a/tests/unit/manifest/testcase.yaml
+++ b/tests/unit/manifest/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  suit-processor.unit.manifest:
+    platform_allow: native_posix native_posix_64 mps2_an521
+    tags: suit-processor suit-manifest


### PR DESCRIPTION
This PR is a part of a bigger effort of allowing to process dependency manifests.