### PR TITLE
platform: Rename retrive to retrieve_manifest

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ The platform contains everything that has side-effects, i.e. writing of payloads
  * Resolving of component IDs, which amounts to keeping track of the memory layout
  * Storing and comparing sequence numbers, because this should be hardware-backed to prevent tampering
  * Comparing vendor/class/device IDs, because this needs to be aware of component IDs.
- * Fetching of payloads, since this needs to be performed on whatever protcols are available on the platform.
+ * Fetching of payloads, since this needs to be performed on whatever protocols are available on the platform.
  * Booting of images, because this is dependent on the architecture of the platform, as well as the OS.
 
 The platform is implemented either in this repository or out-of-tree.
@@ -85,7 +85,7 @@ Or, a temporary component (described below) will typically have a matching read_
 ### Temporary components
 
 Whenever a manifest needs somewhere arbitrary to put a payload while performing the update, it can request a temporary component.
-"Temporary" means the component will live only until the current invokation of the manifest is complete, either
+"Temporary" means the component will live only until the current invocation of the manifest is complete, either
 
  * During the update (during suit-payload-fetch + suit-install), or
  * During secure boot (during suit-validate + suit-load + suit-invoke)

--- a/include/fih.h
+++ b/include/fih.h
@@ -395,7 +395,7 @@ void fih_cfi_decrement(void);
  * The FIH_CFI_PRECALL_BLOCK/FIH_CFI_POSTCALL_BLOCK pair mainly protect function
  * calls from fault injection. Fault injection may attack a function to skip its
  * critical steps which are not function calls. It is difficult for the caller
- * to dectect the injection as long as the function successfully returns.
+ * to detect the injection as long as the function successfully returns.
  *
  * The following macros can be called in a function to track the critical steps,
  * especially those which are not function calls.

--- a/include/suit_decoder.h
+++ b/include/suit_decoder.h
@@ -38,7 +38,7 @@ int suit_decoder_decode_envelope(struct suit_decoder_state *state, uint8_t *enve
 
 /** @brief Verify the SUIT manifest digest.
  *
- * @details In this step the manifest payload will be checked agains the digest, stored inside the authentication wrapper.
+ * @details In this step the manifest payload will be checked against the digest, stored inside the authentication wrapper.
  *          This step does not decode the manifest payload contents.
  *
  * @note This function checks the integrity of the manifest structure.
@@ -68,7 +68,7 @@ int suit_decoder_decode_manifest(struct suit_decoder_state *state);
 
 /** @brief Authenticate the SUIT manifest.
  *
- * @details In this step the manifest digest will be checked agains all of the signatures present
+ * @details In this step the manifest digest will be checked against all of the signatures present
  *          inside the authentication wrappers.
  *          If the envelope does not contain signatures, the @p suit_plat_authorize_unsigned_manifest
  *          platform API will be used to authorize the manifest.
@@ -101,7 +101,7 @@ int suit_decoder_authorize_manifest(struct suit_decoder_state *state);
  * @details In this step the pointers to the command sequences inside the output
  *          manifest structure are populated.
  *          All of the severed sequences are verified through their digests.
- *          If there is a severed sequence without a digest, this funtion will fail.
+ *          If there is a severed sequence without a digest, this function will fail.
  *
  * @note This function does not check the command sequences contents.
  *

--- a/include/suit_platform.h
+++ b/include/suit_platform.h
@@ -250,7 +250,7 @@ int suit_plat_sequence_completed(enum suit_command_sequence seq_name, struct zcb
  *
  * @returns SUIT_SUCCESS if the manifest was returned, error code otherwise.
  */
-int suit_plat_retrive_manifest(suit_component_t component_handle, uint8_t **envelope_str, size_t *envelope_len);
+int suit_plat_retrieve_manifest(suit_component_t component_handle, uint8_t **envelope_str, size_t *envelope_len);
 
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT
 /** @brief Check that the given fetch operation can be performed.

--- a/src/suit_condition.c
+++ b/src/suit_condition.c
@@ -158,7 +158,7 @@ int suit_condition_dependency_integrity(struct suit_processor_state *state,
 
 	if (seq_exec_state->cmd_exec_state == SUIT_SEQ_EXEC_DEFAULT_STATE) {
 		/** Return a pointer to the manifest contents, stored inside the component. */
-		retval = suit_plat_retrive_manifest(component_params->component_handle, &envelope_str, &envelope_len);
+		retval = suit_plat_retrieve_manifest(component_params->component_handle, &envelope_str, &envelope_len);
 
 		if (retval == SUIT_SUCCESS) {
 			retval = suit_processor_load_envelope(state, envelope_str, envelope_len);

--- a/src/suit_directive.c
+++ b/src/suit_directive.c
@@ -380,7 +380,7 @@ int suit_directive_process_dependency(struct suit_processor_state *state, struct
 		retval = seq_exec_state->retval;
 	} else if (seq_exec_state->cmd_exec_state == SUIT_SEQ_EXEC_DEFAULT_STATE) {
 		/** Return a pointer to the manifest contents, stored inside the component. */
-		retval = suit_plat_retrive_manifest(component_params->component_handle, &envelope_str, &envelope_len);
+		retval = suit_plat_retrieve_manifest(component_params->component_handle, &envelope_str, &envelope_len);
 
 		if (retval == SUIT_SUCCESS) {
 			retval = suit_processor_load_envelope(state, envelope_str, envelope_len);

--- a/src/suit_seq_exec.c
+++ b/src/suit_seq_exec.c
@@ -180,7 +180,7 @@ int suit_seq_exec_schedule(struct suit_processor_state *state, struct suit_manif
 		return SUIT_ERR_AGAIN;
 	}
 
-	SUIT_ERR("Unable to schedule sequece execution: execution stack overflow\r\n");
+	SUIT_ERR("Unable to schedule sequence execution: execution stack overflow\r\n");
 
 	return SUIT_ERR_OVERFLOW;
 }

--- a/tests/unit/decoder/src/test_authenticate_manifest.c
+++ b/tests/unit/decoder/src/test_authenticate_manifest.c
@@ -555,7 +555,7 @@ static uint8_t signature1_w32bitkey_cbor[] = {
 			0x01, /* alg_id */ 0x26, /* ES256 */
 			0x04, /* key_id */
 				0x45, /* bytes(5) */
-				0x1A, /* 32-bit unsigned intger */
+				0x1A, /* 32-bit unsigned integer */
 				0x7F, 0xFF, 0xFF, 0xE0,
 		0x40, /* external_aad: bytes(0) */
 		0x58, 0x24, /* payload: bytes(36) */

--- a/tests/unit/fetch_integrated_manifests/src/app.c
+++ b/tests/unit/fetch_integrated_manifests/src/app.c
@@ -148,11 +148,11 @@ void app_assert_envelope_integrity(bool installed)
 	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&(signature1_cbor[23]), manifest_digest, sizeof(manifest_digest), "Please fix the test: application manifest digest inside signature structure is incorrect");
 
 	/* read manifest from the candidate component data */
-	__cmock_suit_plat_retrive_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_str();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_app_envelope_payload.value);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_len();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_len(&exp_app_envelope_payload.len);
+	__cmock_suit_plat_retrieve_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_str();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_app_envelope_payload.value);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_len();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_len(&exp_app_envelope_payload.len);
 
 	/* authorization */
 	__cmock_suit_plat_check_digest_ExpectComplexArgsAndReturn(suit_cose_sha256, &exp_manifest_digest, &exp_manifest_payload, SUIT_SUCCESS);
@@ -179,11 +179,11 @@ void app_assert_envelope_authorization(bool installed)
 	suit_component_t checked_component = installed ? app_component_handle : candidate_component_handle;
 
 	/* read manifest from the candidate component data */
-	__cmock_suit_plat_retrive_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_str();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_app_envelope_payload.value);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_len();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_len(&exp_app_envelope_payload.len);
+	__cmock_suit_plat_retrieve_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_str();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_app_envelope_payload.value);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_len();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_len(&exp_app_envelope_payload.len);
 
 	__cmock_suit_plat_check_digest_ExpectComplexArgsAndReturn(suit_cose_sha256, &exp_manifest_digest, &exp_manifest_payload, SUIT_SUCCESS);
 	__cmock_suit_plat_authenticate_manifest_ExpectComplexArgsAndReturn(&exp_app_manifest_id, suit_cose_es256, NULL, &signature, &exp_signature, SUIT_SUCCESS);

--- a/tests/unit/fetch_integrated_manifests/src/radio.c
+++ b/tests/unit/fetch_integrated_manifests/src/radio.c
@@ -148,11 +148,11 @@ void radio_assert_envelope_integrity(bool installed)
 	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&(signature1_cbor[23]), manifest_digest, sizeof(manifest_digest), "Please fix the test: radio manifest digest inside signature structure is incorrect");
 
 	/* read manifest from the candidate component data */
-	__cmock_suit_plat_retrive_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_str();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_radio_envelope_payload.value);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_len();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_len(&exp_radio_envelope_payload.len);
+	__cmock_suit_plat_retrieve_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_str();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_radio_envelope_payload.value);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_len();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_len(&exp_radio_envelope_payload.len);
 
 	/* authorization */
 	__cmock_suit_plat_check_digest_ExpectComplexArgsAndReturn(suit_cose_sha256, &exp_manifest_digest, &exp_manifest_payload, SUIT_SUCCESS);
@@ -179,11 +179,11 @@ void radio_assert_envelope_authorization(bool installed)
 	suit_component_t checked_component = installed ? radio_component_handle : candidate_component_handle;
 
 	/* read manifest from the candidate component data */
-	__cmock_suit_plat_retrive_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_str();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_radio_envelope_payload.value);
-	__cmock_suit_plat_retrive_manifest_IgnoreArg_envelope_len();
-	__cmock_suit_plat_retrive_manifest_ReturnThruPtr_envelope_len(&exp_radio_envelope_payload.len);
+	__cmock_suit_plat_retrieve_manifest_ExpectAndReturn(checked_component, NULL, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_str();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_str((uint8_t**)&exp_radio_envelope_payload.value);
+	__cmock_suit_plat_retrieve_manifest_IgnoreArg_envelope_len();
+	__cmock_suit_plat_retrieve_manifest_ReturnThruPtr_envelope_len(&exp_radio_envelope_payload.len);
 
 	__cmock_suit_plat_check_digest_ExpectComplexArgsAndReturn(suit_cose_sha256, &exp_manifest_digest, &exp_manifest_payload, SUIT_SUCCESS);
 	__cmock_suit_plat_authenticate_manifest_ExpectComplexArgsAndReturn(&exp_radio_manifest_id, suit_cose_es256, NULL, &signature, &exp_signature, SUIT_SUCCESS);


### PR DESCRIPTION
Fix spelling issue in platform function name.