### PR TITLE
core: Fix problems reported by coverity

### DIFF
--- a/src/suit_condition.c
+++ b/src/suit_condition.c
@@ -155,8 +155,8 @@ int suit_condition_abort(struct suit_processor_state *state,
 int suit_condition_dependency_integrity(struct suit_processor_state *state,
 		struct suit_manifest_params *component_params)
 {
-	uint8_t *envelope_str;
-	size_t envelope_len;
+	uint8_t *envelope_str = NULL;
+	size_t envelope_len = 0;
 	struct suit_seq_exec_state *seq_exec_state;
 	struct suit_manifest_state *manifest_state;
 

--- a/src/suit_directive.c
+++ b/src/suit_directive.c
@@ -352,8 +352,8 @@ int suit_directive_set_parameters(struct suit_processor_state *state,
 
 int suit_directive_process_dependency(struct suit_processor_state *state, struct suit_manifest_params *component_params)
 {
-	uint8_t *envelope_str;
-	size_t envelope_len;
+	uint8_t *envelope_str = NULL;
+	size_t envelope_len = 0;
 	struct suit_seq_exec_state *seq_exec_state;
 	struct suit_manifest_state *manifest_state;
 


### PR DESCRIPTION
In the following functions:
- suit_condition_dependency_integrity
- suit_directive_process_dependency the local variables `envelope_str` and `envelope_len` were uninitialized. The impact of this issue is low, because the current implementation initializes those values in suit_plat_retrieve_manifest.

The implementation guards access to those values through the return value of suit_plat_retrieve_manifest.