### PR TITLE
Fix missing extern "C" in SUIT headers

### DIFF
--- a/include/suit.h
+++ b/include/suit.h
@@ -10,6 +10,9 @@
 #include <stdint.h>
 #include <suit_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** @brief Initialize SUIT processor module
  *
@@ -47,5 +50,9 @@ int suit_process_sequence(uint8_t *envelope_str, size_t envelope_len, enum suit_
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
 int suit_processor_get_manifest_metadata(uint8_t *envelope_str, size_t envelope_len, bool authenticate, struct zcbor_string *manifest_component_id, struct zcbor_string *digest, enum suit_cose_alg *alg, unsigned int *seq_num);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_H__ */

--- a/include/suit_condition.h
+++ b/include/suit_condition.h
@@ -9,6 +9,9 @@
 
 #include "suit_processor.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** Check a vendor ID based on the configured parameters. */
 int suit_condition_vendor_identifier(struct suit_processor_state *state,
@@ -41,5 +44,9 @@ int suit_condition_dependency_integrity(struct suit_processor_state *state,
 /** Check if component is a dependency manifest component. */
 int suit_condition_is_dependency(struct suit_processor_state *state,
 		struct suit_manifest_params *component_params);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_CONDITION_H__ */

--- a/include/suit_decoder.h
+++ b/include/suit_decoder.h
@@ -9,6 +9,9 @@
 
 #include <suit_processor.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** @brief Initialize the decoder context.
  *
@@ -128,5 +131,9 @@ int suit_decoder_decode_sequences(struct suit_decoder_state *state);
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
 int suit_decoder_create_components(struct suit_decoder_state *state);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_DECODER_H__ */

--- a/include/suit_directive.h
+++ b/include/suit_directive.h
@@ -10,6 +10,9 @@
 #include "suit_processor.h"
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** Set the current component indices. This decides which component(s)
  *  are affected by subsequent commands. */
@@ -51,5 +54,9 @@ int suit_directive_set_parameters(struct suit_processor_state *state,
 
 /** Process the current sequence of the dependency manifest. */
 int suit_directive_process_dependency(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_DIRECTIVE_H__ */

--- a/include/suit_manifest.h
+++ b/include/suit_manifest.h
@@ -9,6 +9,10 @@
 
 #include <suit_processor.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** @brief Assign and initialize the memory to store SUIT component parameters.
  *
  * @param[in] params  Reference to an array holding the component parameters values.
@@ -85,5 +89,9 @@ struct zcbor_string *suit_manifest_get_command_seq(struct suit_manifest_state *m
  * @returns SUIT_SUCCESS if the integrated payload was found and the structure was returned, error code otherwise.
  */
 int suit_manifest_get_integrated_payload(struct suit_manifest_state *manifest, struct zcbor_string *uri, struct zcbor_string *payload);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_MANIFEST_H__ */

--- a/include/suit_platform.h
+++ b/include/suit_platform.h
@@ -10,6 +10,9 @@
 #include "suit_types.h"
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 #ifndef SUIT_DBG
 #define SUIT_DBG(...)
@@ -315,5 +318,9 @@ int suit_plat_check_write(suit_component_t dst_handle, struct zcbor_string *cont
 int suit_plat_check_invoke(suit_component_t image_handle, struct zcbor_string *invoke_args);
 
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_PLATFORM_H__ */

--- a/include/suit_processor.h
+++ b/include/suit_processor.h
@@ -10,6 +10,10 @@
 #include <suit_types.h>
 #include "manifest_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /* Forward declaration of the SUIT processor state, used inside the command processor callback. */
 struct suit_processor_state;
 
@@ -241,5 +245,9 @@ int suit_processor_load_envelope(struct suit_processor_state *state, uint8_t *en
  */
 int suit_processor_override_state(struct suit_processor_state *new_state);
 #endif /* CONFIG_UNITY */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_PROCESSOR_H__ */

--- a/include/suit_report.h
+++ b/include/suit_report.h
@@ -10,6 +10,9 @@
 #include "suit_types.h"
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** Construct a report for the given command.
  *
@@ -22,5 +25,8 @@ int suit_construct_report(unsigned int command, int result,
 		struct suit_manifest_params *parameters,
 		struct suit_report *report);
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_REPORT_H__ */

--- a/include/suit_schedule_seq.h
+++ b/include/suit_schedule_seq.h
@@ -9,6 +9,9 @@
 
 #include "suit_processor.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** Schedule execution of all commands in the sequence from the current manifest.
  *
@@ -40,5 +43,9 @@ int suit_schedule_validation(struct suit_processor_state *state, struct suit_man
  * @returns SUIT_ERR_SUCCESS if the sequence was successfully processed, error code otherwise.
  */
 int suit_process_scheduled(struct suit_processor_state *state);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_SCHEDULE_SEQ_H__ */

--- a/include/suit_seq_exec.h
+++ b/include/suit_seq_exec.h
@@ -10,6 +10,9 @@
 #include "suit_processor.h"
 #include <manifest_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /** @brief Schedule the command sequence for execution.
  *
@@ -133,5 +136,9 @@ int suit_exec_component_handle_from_idx(struct suit_seq_exec_state *seq_exec_sta
  * @returns SUIT_SUCCESS if the integrated payload was found and returned, error code otherwise.
  */
 int suit_exec_find_integrated_payload(struct suit_seq_exec_state *seq_exec_state, struct zcbor_string *uri, struct zcbor_string *payload);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_SEQ_EXEC_H__ */

--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -11,6 +11,9 @@
 #include <string.h>
 #include <zcbor_common.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 #define SUIT_MAX_NUM_SIGNERS 2  ///! The maximum number of signers.
 #define SUIT_MAX_NUM_COMPONENT_ID_PARTS 5  ///! The maximum number of bytestrings in a component ID.
@@ -98,5 +101,8 @@ static inline bool suit_compare_zcbor_strings(const struct zcbor_string *str1, c
 	return (str1 != NULL) && (str2 != NULL) && (str1->len == str2->len) && (memcmp(str1->value, str2->value, str1->len) == 0);
 }
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* SUIT_TYPES_H__ */


### PR DESCRIPTION
Ref: NCSDK-24721
Missing extern "C" in SUIT headers in suit-processor and secdom