### PR TITLE
Add support for suit-parameter-content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/build*/
 **/__pycache__/
 twister-out*
+.vscode*

--- a/cddl/manifest.cddl
+++ b/cddl/manifest.cddl
@@ -185,7 +185,7 @@ $$SUIT_Parameters //= (suit-parameter-device-identifier => RFC4122_UUID)
 
 ; $$SUIT_Parameters //= (suit-parameter-custom => int/bool/tstr/bstr)
 
-; $$SUIT_Parameters //= (suit-parameter-content => bstr)
+$$SUIT_Parameters //= (suit-parameter-content => bstr)
 ; $$SUIT_Parameters //= (suit-parameter-strict-order => bool)
 $$SUIT_Parameters //= (suit-parameter-soft-failure => bool)
 
@@ -275,7 +275,7 @@ suit-parameter-component-slot    = 5
 ; suit-parameter-strict-order      = 12
 suit-parameter-soft-failure      = 13
 suit-parameter-image-size        = 14
-; suit-parameter-content           = 18
+suit-parameter-content           = 18
 
 suit-parameter-uri               = 21
 suit-parameter-source-component  = 22

--- a/include/suit_processor.h
+++ b/include/suit_processor.h
@@ -54,6 +54,7 @@ struct suit_manifest_params {
 	struct zcbor_string cid;
 	struct zcbor_string image_digest;
 	size_t image_size;
+	struct zcbor_string content;
 	unsigned int component_slot;
 	struct zcbor_string uri;
 	unsigned int source_component;
@@ -64,6 +65,7 @@ struct suit_manifest_params {
 	bool cid_set;
 	bool image_digest_set;
 	bool image_size_set;
+	bool content_set;
 	bool component_slot_set;
 	bool uri_set;
 	bool source_component_set;

--- a/src/suit_directive.c
+++ b/src/suit_directive.c
@@ -178,6 +178,11 @@ static int suit_directive_override_parameter(struct SUIT_Parameters_ *param, str
 			return ret;
 		}
 	} break;
+	case _SUIT_Parameters_suit_parameter_content:
+		SUIT_DBG("Override content parameter (handle: 0x%lx)\r\n", dst->component_handle);
+		memcpy(&dst->content, &param->_SUIT_Parameters_suit_parameter_content, sizeof(dst->content));
+		dst->content_set = true;
+		break;
 	case _SUIT_Parameters_suit_parameter_component_slot:
 		SUIT_DBG("Override slot (handle: 0x%lx)\r\n", dst->component_handle);
 		dst->component_slot = param->_SUIT_Parameters_suit_parameter_component_slot;
@@ -293,6 +298,9 @@ static int suit_directive_set_parameter(struct SUIT_Parameters_ *param, struct s
 		break;
 	case _SUIT_Parameters_suit_parameter_image_size:
 		parameter_set = dst->image_size_set;
+		break;
+	case _SUIT_Parameters_suit_parameter_content:
+		parameter_set = dst->content_set;
 		break;
 	case _SUIT_Parameters_suit_parameter_component_slot:
 		parameter_set = dst->component_slot_set;

--- a/tests/unit/seq_execution/include/common_parameters.h
+++ b/tests/unit/seq_execution/include/common_parameters.h
@@ -20,6 +20,7 @@ enum parameter_values {
 	COMPONENT_SLOT,
 	SOFT_FAILURE,
 	IMAGE_SIZE,
+	CONTENT,
 	URI,
 	SOURCE_COMPONENT,
 	INVOKE_ARGS,
@@ -43,6 +44,9 @@ extern uint32_t exp_slot;
 
 /** @brief Expected image size, embedded inside IMAGE_SIZE sequence. */
 extern size_t exp_image_size;
+
+/** @brief Expected content parameter, embedded inside CONTENT sequence. */
+extern struct zcbor_string exp_content;
 
 /** @brief Expected URI, embedded inside URI sequence. */
 extern struct zcbor_string exp_uri;

--- a/tests/unit/seq_execution/src/common_parameters.c
+++ b/tests/unit/seq_execution/src/common_parameters.c
@@ -97,6 +97,17 @@ static uint8_t image_size_cmd[] = {
 
 size_t exp_image_size = 0x01020304;
 
+static uint8_t content_cmd[] = {
+	0x12, /* uint(suit-parameter-content) */
+	0x48, /* bytes (8) */
+		0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89
+};
+
+struct zcbor_string exp_content = {
+	.value = &content_cmd[2],
+	.len = 8,
+};
+
 static uint8_t uri_cmd[] = {
 	0x15, /* uint(suit-parameter-uri) */
 	0x68, /* text (8 characters) */
@@ -148,6 +159,7 @@ static struct parameter_value *find_param(enum parameter_values param)
 		{COMPONENT_SLOT, component_slot_cmd, sizeof(component_slot_cmd)},
 		{SOFT_FAILURE, soft_failure_cmd, sizeof(soft_failure_cmd)},
 		{IMAGE_SIZE, image_size_cmd, sizeof(image_size_cmd)},
+		{CONTENT, content_cmd, sizeof(content_cmd)},
 		{URI, uri_cmd, sizeof(uri_cmd)},
 		{SOURCE_COMPONENT, source_component_cmd, sizeof(source_component_cmd)},
 		{INVOKE_ARGS, invoke_args_cmd, sizeof(invoke_args_cmd)},

--- a/tests/unit/seq_execution/src/main.c
+++ b/tests/unit/seq_execution/src/main.c
@@ -69,7 +69,7 @@ void test_seq_execution_condition_dependency_integrity_fail(void);
 void test_seq_execution_condition_dependency_integrity_invalid(void);
 
 /* suit-directive-override-parameters tests */
-void test_seq_execution_override_parameter_single_component_3params(void);
+void test_seq_execution_override_parameter_single_component_4params(void);
 void test_seq_execution_override_parameter_single_component_6params(void);
 void test_seq_execution_override_parameter_single_component_7params(void);
 void test_seq_execution_override_parameter_multiple_components_3params(void);
@@ -77,9 +77,9 @@ void test_seq_execution_override_parameter_soft_failure(void);
 void test_seq_execution_override_parameter_soft_failure_nested(void);
 
 /* suit-directive-set-parameters tests */
-void test_seq_execution_set_parameter_single_component_3params(void);
+void test_seq_execution_set_parameter_single_component_4params(void);
 void test_seq_execution_set_parameter_single_component_6params(void);
-void test_seq_execution_set_parameter_single_component_7params(void);
+// void test_seq_execution_set_parameter_single_component_7params(void);
 void test_seq_execution_set_parameter_multiple_components_3params(void);
 void test_seq_execution_set_parameter_soft_failure(void);
 void test_seq_execution_set_parameter_multiple_components_image_size_failed(void);

--- a/tests/unit/seq_execution/src/test_directive_override_parameters.c
+++ b/tests/unit/seq_execution/src/test_directive_override_parameters.c
@@ -28,7 +28,7 @@ static int execute_command_sequence(struct suit_processor_state *state, struct z
 	return ret;
 }
 
-void test_seq_execution_override_parameter_single_component_3params(void)
+void test_seq_execution_override_parameter_single_component_4params(void)
 {
 	uint8_t seq_cmd[128];
 	struct zcbor_string seq = {
@@ -39,12 +39,13 @@ void test_seq_execution_override_parameter_single_component_3params(void)
 	/* Common header */
 	seq_cmd[0] = 0x82; /* list (2 elements - 1 command) */
 	seq_cmd[1] = 0x14; /* uint(suit-directive-override-parameters) */
-	seq_cmd[2] = 0xa3; /* map (3) */
+	seq_cmd[2] = 0xa4; /* map (4) */
 
 	enum parameter_values params[] = {
 		SOURCE_COMPONENT,
 		INVOKE_ARGS,
 		DEVICE_ID,
+		CONTENT
 	};
 
 	seq.len = bootstrap_parameters(params, ZCBOR_ARRAY_SIZE(params), &seq_cmd[3], sizeof(seq_cmd) - 3) + 3;
@@ -73,6 +74,10 @@ void test_seq_execution_override_parameter_single_component_3params(void)
 	TEST_ASSERT_EQUAL_MESSAGE(true, state.components[0].did_set, "Device ID set, but flag is not updated");
 	TEST_ASSERT_EQUAL_MESSAGE(exp_did.len, state.components[0].did.len, "Device ID set with invalid length");
 	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(exp_did.value, state.components[0].did.value, exp_did.len, "Device ID set with invalid value");
+
+	TEST_ASSERT_EQUAL_MESSAGE(true, state.components[0].content_set, "Content set, but flag is not updated");
+	TEST_ASSERT_EQUAL_MESSAGE(exp_content.len, state.components[0].content.len, "Content set with invalid length");
+	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(exp_content.value, state.components[0].content.value, exp_content.len, "Content set with invalid value");
 }
 
 void test_seq_execution_override_parameter_single_component_6params(void)
@@ -133,6 +138,7 @@ void test_seq_execution_override_parameter_single_component_6params(void)
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].source_component_set, "Source component not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].invoke_args_set, "Invoke args not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].did_set, "Device ID set, but flag was updated");
+	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 }
 
 void test_seq_execution_override_parameter_single_component_7params(void)
@@ -172,6 +178,7 @@ void test_seq_execution_override_parameter_single_component_7params(void)
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].image_digest_set, "Image digest not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].component_slot_set, "Component slot not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].image_size_set, "Image size not set, but flag was updated");
+	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].uri_set, "URI not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].source_component_set, "Source component not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].invoke_args_set, "Invoke args not set, but flag was updated");
@@ -217,6 +224,7 @@ void test_seq_execution_override_parameter_multiple_components_3params(void)
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].image_digest_set, "Image digest not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].component_slot_set, "Component slot not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].image_size_set, "Image size not set, but flag was updated");
+		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].uri_set, "URI not set, but flag was updated");
 
 		TEST_ASSERT_EQUAL_MESSAGE(true, state.components[i].source_component_set, "Source component set, but flag is not updated");

--- a/tests/unit/seq_execution/src/test_directive_set_parameters.c
+++ b/tests/unit/seq_execution/src/test_directive_set_parameters.c
@@ -28,7 +28,7 @@ static int execute_command_sequence(struct suit_processor_state *state, struct z
 	return ret;
 }
 
-void test_seq_execution_set_parameter_single_component_3params(void)
+void test_seq_execution_set_parameter_single_component_4params(void)
 {
 	uint8_t seq_cmd[128];
 	struct zcbor_string seq = {
@@ -39,12 +39,13 @@ void test_seq_execution_set_parameter_single_component_3params(void)
 	/* Common header */
 	seq_cmd[0] = 0x82; /* list (2 elements - 1 command) */
 	seq_cmd[1] = 0x13; /* uint(suit-directive-set-parameters) */
-	seq_cmd[2] = 0xa3; /* map (3) */
+	seq_cmd[2] = 0xa4; /* map (4) */
 
 	enum parameter_values params[] = {
 		SOURCE_COMPONENT,
 		INVOKE_ARGS,
 		DEVICE_ID,
+		CONTENT,
 	};
 
 	seq.len = bootstrap_parameters(params, ZCBOR_ARRAY_SIZE(params), &seq_cmd[3], sizeof(seq_cmd) - 3) + 3;
@@ -73,6 +74,10 @@ void test_seq_execution_set_parameter_single_component_3params(void)
 	TEST_ASSERT_EQUAL_MESSAGE(true, state.components[0].did_set, "Device ID set, but flag is not updated");
 	TEST_ASSERT_EQUAL_MESSAGE(exp_did.len, state.components[0].did.len, "Device ID set with invalid length");
 	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(exp_did.value, state.components[0].did.value, exp_did.len, "Device ID set with invalid value");
+
+	TEST_ASSERT_EQUAL_MESSAGE(true, state.components[0].content_set, "Content set, but flag is not updated");
+	TEST_ASSERT_EQUAL_MESSAGE(exp_content.len, state.components[0].content.len, "Content set with invalid length");
+	TEST_ASSERT_EQUAL_MEMORY_MESSAGE(exp_content.value, state.components[0].content.value, exp_content.len, "Content set with invalid value");
 }
 
 void test_seq_execution_set_parameter_single_component_6params(void)
@@ -133,6 +138,7 @@ void test_seq_execution_set_parameter_single_component_6params(void)
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].source_component_set, "Source component not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].invoke_args_set, "Invoke args not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].did_set, "Device ID set, but flag was updated");
+	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 }
 
 void test_seq_execution_set_parameter_single_component_7params(void)
@@ -172,6 +178,7 @@ void test_seq_execution_set_parameter_single_component_7params(void)
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].image_digest_set, "Image digest not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].component_slot_set, "Component slot not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].image_size_set, "Image size not set, but flag was updated");
+	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].uri_set, "URI not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].source_component_set, "Source component not set, but flag was updated");
 	TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].invoke_args_set, "Invoke args not set, but flag was updated");
@@ -217,6 +224,7 @@ void test_seq_execution_set_parameter_multiple_components_3params(void)
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].image_digest_set, "Image digest not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].component_slot_set, "Component slot not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].image_size_set, "Image size not set, but flag was updated");
+		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].uri_set, "URI not set, but flag was updated");
 
 		TEST_ASSERT_EQUAL_MESSAGE(true, state.components[i].source_component_set, "Source component set, but flag is not updated");
@@ -314,6 +322,7 @@ void test_seq_execution_set_parameter_multiple_components_image_size_failed(void
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].source_component_set, "Source component not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].invoke_args_set, "Invoke args not set, but flag was updated");
 		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[i].did_set, "Device ID not set, but flag was updated");
+		TEST_ASSERT_EQUAL_MESSAGE(false, state.components[0].content_set, "Content not set, but flag was updated");
 	}
 
 	TEST_ASSERT_EQUAL_MESSAGE(true, state.components[0].image_size_set, "Image size set before command execution, but flag was updated");


### PR DESCRIPTION
Ref: NCSDK-20922

This PR adds support for the parameter suit-parameter-content (allowing to use it with suit-directive-override-parameters and suit-directive-set-parameters).