### PR TITLE
Dry run for PARSE executed with the same scope as for INSTALL

### DIFF
--- a/src/suit.c
+++ b/src/suit.c
@@ -54,7 +54,16 @@ static int suit_dry_run_manifest(struct suit_manifest_state *manifest_state,
 
 	if (seq_name == SUIT_SEQ_PARSE)
 	{
-		return SUIT_SUCCESS;
+		/**
+		 * The PARSE sequence is used by tests to verify various aspects how will the firmware
+		 * react on invalid manifests. It is currently only run on the Secure Domain FW, which
+		 * is why the scope of the dry run is the same as the scope for the INSTALL sequence
+		 * (all sequences run by the Secure Domain).
+		 * Currently the PARSE sequence is useless in context of the application core.
+		 * TODO: NCSDK-26242 - discuss what should be the scope of the manifest validation
+		 * by the PARSE sequence and on the application core side.
+		 */
+		seq_name = SUIT_SEQ_INSTALL;
 	}
 
 	if (seq_name <= SUIT_SEQ_PAYLOAD_FETCH)


### PR DESCRIPTION
This commit makes the dry run for the PARSE sequence run the install, validate and invoke sequences. This allows the tests to properly check if the suit-processor rejects manifests with errors in these sequences.

Ref: NCSDK-25996