### PR TITLE
Increase maximum number of components

### DIFF
--- a/cddl/manifest.cddl
+++ b/cddl/manifest.cddl
@@ -90,7 +90,7 @@ SUIT_Common = {
   0*1 $$SUIT_Common-extensions,
 }
 
-SUIT_Components           = [ 1*4 SUIT_Component_Identifier ]
+SUIT_Components           = [ 1*5 SUIT_Component_Identifier ]
 
 ;REQUIRED to implement:
 suit-cose-hash-algs /= cose-alg-sha-256

--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #define SUIT_MAX_NUM_SIGNERS 2  ///! The maximum number of signers.
 #define SUIT_MAX_NUM_COMPONENT_ID_PARTS 5  ///! The maximum number of bytestrings in a component ID.
-#define SUIT_MAX_NUM_COMPONENTS 4  ///! The maximum number of components referenced in the manifest.
+#define SUIT_MAX_NUM_COMPONENTS 5  ///! The maximum number of components referenced in the manifest.
 #define SUIT_MAX_NUM_COMPONENT_PARAMS (SUIT_MAX_NUM_COMPONENTS * SUIT_MANIFEST_STACK_MAX_ENTRIES) ///! The maximum number of active components during processing dependency manifests.
 #define SUIT_MAX_NUM_INTEGRATED_PAYLOADS 5  ///! The maximum number of integrated payloads in a single manifest.
 #define SUIT_MAX_COMMAND_ARGS 3  ///! The maximum number of arguments consumed by a single command.

--- a/tests/unit/decoder/src/test_decode_manifest.c
+++ b/tests/unit/decoder/src/test_decode_manifest.c
@@ -249,7 +249,7 @@ static uint8_t cbor_envelope_with_single_null_component[] = {
 				0x80, /* array (0 elements) */
 };
 
-static uint8_t cbor_envelope_with_5_components[] = {
+static uint8_t cbor_envelope_with_6_components[] = {
 	0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
 	0xa2, /* map (2 elements) */
 
@@ -259,15 +259,18 @@ static uint8_t cbor_envelope_with_5_components[] = {
 			0x40, /* bytes(0) */
 
 	0x03, /* suit-manifest */
-	0x58, 0x19, /* bytes(25) */
+	0x58, 0x1c, /* bytes(28) */
 	0xa3, /* map (3 elements) */
 	0x01, /* suit-manifest-version */ 0x01,
 	0x02, /* suit-manifest-sequence-number */ 0x10,
 	0x03, /* suit-common */
-		0x52, /* bytes(18) */
+		0x55, /* bytes(21) */
 		0xA1, /* map (1 element) */
 			0x02, /* suit-components */
-				0x85, /* array (5 elements) */
+				0x86, /* array (6 elements) */
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
 				0x81, /* array (1 element) */
 					0x41, /* bytes(1) */
 					'M',
@@ -530,8 +533,8 @@ void test_decode_manifest_invalid_input_bytes(void)
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{
-			.envelope = cbor_envelope_with_5_components,
-			.envelope_size = sizeof(cbor_envelope_with_5_components),
+			.envelope = cbor_envelope_with_6_components,
+			.envelope_size = sizeof(cbor_envelope_with_6_components),
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{

--- a/tests/unit/manifest/src/main.c
+++ b/tests/unit/manifest/src/main.c
@@ -169,19 +169,19 @@ void test_append_component_fill_array(void)
 	 * The remaining component IDs will be created by changing the length of the static string.
 	 */
 	static struct zcbor_string sample_component_0 = {
-		.value = "TEST_COMPONENT_0123456789abcdef67890",
+		.value = "TEST_COMPONENT_0123456789abcdef67890abcd",
 		.len = sizeof("TEST_COMPONENT_0"),
 	};
 
 	/* Verify that the test boundaries can be reached. */
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENTS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);
 
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENT_PARAMS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);
@@ -474,19 +474,19 @@ void test_append_dependency_fill_array(void)
 	 * The remaining component IDs will be created by changing the length of the static string.
 	 */
 	static struct zcbor_string sample_component_0 = {
-		.value = "TEST_COMPONENT_0123456789abcdef67890",
+		.value = "TEST_COMPONENT_0123456789abcdef67890abcd",
 		.len = sizeof("TEST_COMPONENT_0"),
 	};
 
 	/* Verify that the test boundaries can be reached. */
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENTS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);
 
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENT_PARAMS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);


### PR DESCRIPTION
Until now the maximum number of components was four. A pretty basic use case when this would be to few
is a root manifest with the following components:
- component for Nordic top manifest
- component for Application manifests
- component for Radio manifest
- "candidate image" component
- Cache pool component.

The cache pool component would be needed if fetching of one of the manifests would be required.