### PR TITLE
core: Align error codes with report reasons

### DIFF
--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -29,8 +29,9 @@ extern "C" {
 
 /** Errors from the suit API
  *
- * See also https://www.ietf.org/archive/id/draft-ietf-suit-manifest-17.html#name-manifest-processor-setup
- * for more error conditions.
+ * See also https://www.ietf.org/archive/id/draft-ietf-suit-manifest-25.html#name-manifest-processor-setup
+ * and https://www.ietf.org/archive/id/draft-ietf-suit-report-08.html#section-4-14
+ * for more report reasons and error conditions.
  */
 #define SUIT_SUCCESS                      0
 #define SUIT_FAIL_CONDITION               1 // Test failed (e.g. Vendor ID/Class ID).
@@ -51,6 +52,9 @@ extern "C" {
 #define SUIT_ERR_MISSING_COMPONENT        17 // Missing required component from a Component Set.
 #define SUIT_ERR_CRASH                    18 // Application crashed when executed.
 #define SUIT_ERR_TIMEOUT                  19 // Watchdog timeout occurred.
+#define SUIT_ERR_UNSUPPORTED_COSE         20 // Unsupported type of COSE structure encountered.
+#define SUIT_ERR_UNSUPPORTED_ALG          21 // Unsupported COSE algorithm encountered.
+#define SUIT_ERR_UNAUTHORIZED_COMPONENT   22 // Unauthorized component ID.
 #define SUIT_ERR_AGAIN                    100 // The execution has not yet finished. Call the API again.
 #define SUIT_ERR_OVERFLOW                 101 // The execution context is too small to handle the command sequence.
 #define SUIT_FAIL_SOFT_CONDITION          102 // Test failed (e.g. Vendor ID/Class ID) and soft-failure parameter was set to true.

--- a/src/suit.c
+++ b/src/suit.c
@@ -366,7 +366,7 @@ int suit_processor_get_manifest_metadata(uint8_t *envelope_str, size_t envelope_
 			}
 		} else {
 			/* Other algorithms are not supported. */
-			ret = SUIT_ERR_DECODING;
+			ret = SUIT_ERR_UNSUPPORTED_ALG;
 		}
 
 		if (ret == SUIT_SUCCESS) {

--- a/src/suit_condition.c
+++ b/src/suit_condition.c
@@ -105,7 +105,7 @@ int suit_condition_image_match(struct suit_processor_state *state,
 		}
 	} else {
 		/* Other algorithms are not supported. */
-		return SUIT_ERR_DECODING;
+		return SUIT_ERR_UNSUPPORTED_ALG;
 	}
 
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT

--- a/src/suit_decoder.c
+++ b/src/suit_decoder.c
@@ -64,7 +64,7 @@ static int verify_suit_digest(struct SUIT_Digest *digest, struct zcbor_string *d
 		}
 	} else {
 		/* Other algorithms are not supported. */
-		return SUIT_ERR_DECODING;
+		return SUIT_ERR_UNSUPPORTED_ALG;
 	}
 
 	struct zcbor_string data_bytes = {
@@ -110,12 +110,12 @@ static int cose_sign1_authenticate_digest(struct zcbor_string *manifest_componen
 		&cose_sign1_struct,
 		&cose_sign1_struct_size);
 	if ((ret != ZCBOR_SUCCESS) || (cose_sign1_struct_size != COSE_Sign1_bstr->len)) {
-		return SUIT_ERR_DECODING;
+		return SUIT_ERR_UNSUPPORTED_COSE;
 	}
 
 	/* The ES256 algorithm is enforced by CDDL, so the signature length is known. */
 	if (cose_sign1_struct._COSE_Sign1_signature.len != 64) {
-		return SUIT_ERR_DECODING;
+		return SUIT_ERR_UNSUPPORTED_ALG;
 	}
 
 	/* Construct Sig_structure1 structure */


### PR DESCRIPTION
There is a list of report reasons, that would be great to support in the future. As the first step, let's extend the current list of error codes to at least include all of the report reasons.