### PR TITLE
cddl: expand constrains

### DIFF
--- a/cddl/manifest.cddl
+++ b/cddl/manifest.cddl
@@ -3,12 +3,12 @@
 ; For that reason it has been simplified for that use case:
 ;
 ; Removed unused extensions
-; Limited the number of possible integrated payloads to 5
+; Limited the number of possible integrated payloads to 6
 ; Limited the number of possible authentication blocks to 2
 ; Removed unused COSE types
 ; Removed COSE authentication block from manifest CDDL - defined and parsed by Cose CDDL
 ; Force making suit-text severable.
-; Limited the number of possible component identifiers to 5
+; Limited the number of possible component identifiers to 12
 ; Limited the length of component identifiers to 5 strings
 ; Remove all hash algs except sha256 and sha512
 ; Remove most of text comprehension since the firmware isn't supposed to understand the text.
@@ -26,7 +26,7 @@ SUIT_Envelope = {
   suit-authentication-wrapper => bstr .cbor SUIT_Authentication,
   suit-manifest  => bstr .cbor SUIT_Manifest,
   SUIT_Severable_Manifest_Members,
-  0*5 SUIT_Integrated_Payload,
+  0*6 SUIT_Integrated_Payload,
 ;  * $$SUIT_Envelope_Extensions,
 }
 
@@ -102,7 +102,7 @@ SUIT_Common = {
   0*1 $$SUIT_Common-extensions,
 }
 
-SUIT_Components           = [ 1*5 SUIT_Component_Identifier ]
+SUIT_Components           = [ 1*12 SUIT_Component_Identifier ]
 
 ;REQUIRED to implement:
 suit-cose-hash-algs /= cose-alg-sha-256

--- a/cddl/trust_domains.cddl
+++ b/cddl/trust_domains.cddl
@@ -4,7 +4,7 @@
 ;
 ; Removed unused extensions
 ; Set the maximum number of parameters inside suit-directive-set-parameters to 6
-; Limited the number of possible dependency manifests to 4
+; Limited the number of possible dependency manifests to 7
 ; Remove suit-directive-unlink
 ; Remove suit-uninstall sequence support
 ; Remove delegation chains
@@ -49,7 +49,7 @@ $$SUIT_Common-extensions //= (
     suit-dependencies => SUIT_Dependencies
 )
 SUIT_Dependencies = {
-    1*4 uint => SUIT_Dependency_Metadata
+    1*7 uint => SUIT_Dependency_Metadata
 }
 SUIT_Dependency_Metadata = {
     ? suit-dependency-prefix => SUIT_Component_Identifier

--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -17,9 +17,9 @@ extern "C" {
 
 #define SUIT_MAX_NUM_SIGNERS 2  ///! The maximum number of signers.
 #define SUIT_MAX_NUM_COMPONENT_ID_PARTS 5  ///! The maximum number of bytestrings in a component ID.
-#define SUIT_MAX_NUM_COMPONENTS 5  ///! The maximum number of components referenced in the manifest.
+#define SUIT_MAX_NUM_COMPONENTS 12  ///! The maximum number of components referenced in the manifest.
 #define SUIT_MAX_NUM_COMPONENT_PARAMS (SUIT_MAX_NUM_COMPONENTS * SUIT_MANIFEST_STACK_MAX_ENTRIES) ///! The maximum number of active components during processing dependency manifests.
-#define SUIT_MAX_NUM_INTEGRATED_PAYLOADS 5  ///! The maximum number of integrated payloads in a single manifest.
+#define SUIT_MAX_NUM_INTEGRATED_PAYLOADS 6  ///! The maximum number of integrated payloads in a single manifest.
 #define SUIT_MAX_COMMAND_ARGS 3  ///! The maximum number of arguments consumed by a single command.
 #define SUIT_SUIT_SIG_STRUCTURE1_MAX_LENGTH 95  ///! The maximum length of the Sig_structure1 structure. Current value allows to store up to 512-bit long digests with 32-bit key id.
 #define SUIT_MAX_SEQ_DEPTH 5  ///! The maximum number of command sequences that may be encapsulated.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,4 +10,4 @@ if [ -z "${ZEPHYR_BASE}" ]; then
        exit 1
 fi
 
-$ZEPHYR_BASE/scripts/twister -M -v -T . -W --platform native_posix --platform native_posix_64 $*
+$ZEPHYR_BASE/scripts/twister -M -v -T . -W --platform native_posix --platform native_posix/native/64 $*

--- a/tests/unit/bootstrap_envelope/testcase.yaml
+++ b/tests/unit/bootstrap_envelope/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.bootstrap_envelope:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor run-command-sequence

--- a/tests/unit/decoder/src/main.c
+++ b/tests/unit/decoder/src/main.c
@@ -174,6 +174,7 @@ void test_manifest_digest_minimal_platform_fail(void);
 void test_decode_manifest_invalid_input(void);
 void test_decode_manifest_invalid_state(void);
 void test_decode_manifest_minimal(void);
+void test_decode_manifest_max_components(void);
 void test_decode_manifest_invalid_input_bytes(void);
 void test_decode_manifest_with_component_id(void);
 

--- a/tests/unit/decoder/src/test_decode_envelope.c
+++ b/tests/unit/decoder/src/test_decode_envelope.c
@@ -230,6 +230,9 @@ static uint8_t envelope_with_integrated_payload[] = {
 
 static size_t envelope_with_integrated_payload_gen(size_t n_payloads, uint8_t **envelope)
 {
+	/* Update this value when adding or removing payloads. */
+	const size_t max_payloads = 7;
+
 	static uint8_t envelope_with_integrated_payloads[] = {
 		0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
 		0xa8, /* map (8 elements) */
@@ -263,9 +266,13 @@ static size_t envelope_with_integrated_payload_gen(size_t n_payloads, uint8_t **
 			'#', 'F', 'W', '5',
 		0x41, /* bytes(1) */
 			0x05, /* 5 */
+		0x64, /* text field (4 bytes) */
+			'#', 'F', 'W', '6',
+		0x41, /* bytes(1) */
+			0x05, /* 5 */
 	};
 
-	if (n_payloads > 6) {
+	if (n_payloads > max_payloads) {
 		*envelope = NULL;
 		return 0;
 	}
@@ -273,7 +280,7 @@ static size_t envelope_with_integrated_payload_gen(size_t n_payloads, uint8_t **
 	envelope_with_integrated_payloads[2] = 0xa2 + n_payloads;
 	*envelope = envelope_with_integrated_payloads;
 
-	return sizeof(envelope_with_integrated_payloads) - 7 * (6 - n_payloads);
+	return sizeof(envelope_with_integrated_payloads) - 7 * (max_payloads - n_payloads);
 }
 
 

--- a/tests/unit/decoder/src/test_decode_manifest.c
+++ b/tests/unit/decoder/src/test_decode_manifest.c
@@ -355,7 +355,7 @@ static uint8_t cbor_envelope_with_single_null_component[] = {
 				0x80, /* array (0 elements) */
 };
 
-static uint8_t cbor_envelope_with_6_components[] = {
+static uint8_t cbor_envelope_with_12_components[] = {
 	0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
 	0xa2, /* map (2 elements) */
 
@@ -365,15 +365,93 @@ static uint8_t cbor_envelope_with_6_components[] = {
 			0x40, /* bytes(0) */
 
 	0x03, /* suit-manifest */
-	0x58, 0x1c, /* bytes(28) */
+	0x58, 0x2f, /* bytes(47) */
 	0xa3, /* map (3 elements) */
 	0x01, /* suit-manifest-version */ 0x01,
 	0x02, /* suit-manifest-sequence-number */ 0x10,
 	0x03, /* suit-common */
-		0x55, /* bytes(21) */
+		0x58, 0x27, /* bytes(39) */
 		0xA1, /* map (1 element) */
 			0x02, /* suit-components */
-				0x86, /* array (6 elements) */
+				0x8c, /* array (12 elements) */
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+};
+
+static uint8_t cbor_envelope_with_13_components[] = {
+	0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
+	0xa2, /* map (2 elements) */
+
+	0x02, /* suit-authentication-wrapper */
+		0x42, /* bytes(2) */
+		0x81, /* array (1 element) */
+			0x40, /* bytes(0) */
+
+	0x03, /* suit-manifest */
+	0x58, 0x32, /* bytes(50) */
+	0xa3, /* map (3 elements) */
+	0x01, /* suit-manifest-version */ 0x01,
+	0x02, /* suit-manifest-sequence-number */ 0x10,
+	0x03, /* suit-common */
+		0x58, 0x2a, /* bytes(42) */
+		0xA1, /* map (1 element) */
+			0x02, /* suit-components */
+				0x8d, /* array (13 elements) */
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
 				0x81, /* array (1 element) */
 					0x41, /* bytes(1) */
 					'M',
@@ -422,7 +500,7 @@ static uint8_t cbor_envelope_with_single_dependency_with_empty_prefix[] = {
 					0x01, 0x80,
 };
 
-static uint8_t cbor_envelope_with_5_dependencies[] = {
+static uint8_t cbor_envelope_with_8_dependencies[] = {
 	0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
 	0xa2, /* map (2 elements) */
 
@@ -432,15 +510,24 @@ static uint8_t cbor_envelope_with_5_dependencies[] = {
 			0x40, /* bytes(0) */
 
 	0x03, /* suit-manifest */
-	0x58, 0x2c, /* bytes(44) */
+	0x58, 0x3b, /* bytes(59) */
 	0xa3, /* map (3 elements) */
 	0x01, /* suit-manifest-version */ 0x01,
 	0x02, /* suit-manifest-sequence-number */ 0x10,
 	0x03, /* suit-common */
-		0x58, 0x24, /* bytes(36) */
+		0x58, 0x33, /* bytes(51) */
 		0xA2, /* map (2 elements) */
 			0x02, /* suit-components */
-				0x84, /* array (4 elements) */
+				0x87, /* array (7 elements) */
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
 				0x81, /* array (1 element) */
 					0x41, /* bytes(1) */
 					'M',
@@ -454,7 +541,10 @@ static uint8_t cbor_envelope_with_5_dependencies[] = {
 					0x41, /* bytes(1) */
 					'M',
 			0x01, /* suit-dependencies */
-				0xA5, /* map (5 elements) */
+				0xA8, /* map (8 elements) */
+				0x06, 0xA0, /* 4: {} */
+				0x04, 0xA0, /* 4: {} */
+				0x05, 0xA0, /* 5: {} */
 				0x03, 0xA0, /* 3: {} */
 				0x01, 0xA0, /* 1: {} */
 				0x02, 0xA0, /* 2: {} */
@@ -573,6 +663,21 @@ void test_decode_manifest_minimal(void)
 	TEST_ASSERT_EQUAL_MESSAGE(0x11, state.decoded_manifest->sequence_number, "Incorrect manifest sequence number value");
 }
 
+void test_decode_manifest_max_components(void)
+{
+	int ret = SUIT_SUCCESS;
+
+	init_decode_envelope(cbor_envelope_with_12_components, sizeof(cbor_envelope_with_12_components));
+	state.step = MANIFEST_DIGEST_VERIFIED;
+
+	ret = suit_decoder_decode_manifest(&state);
+	TEST_ASSERT_EQUAL_MESSAGE(SUIT_SUCCESS, ret, "The manifest decoding failed");
+	TEST_ASSERT_EQUAL_MESSAGE(MANIFEST_DECODED, state.step, "Invalid state transition after manifest decoding");
+	TEST_ASSERT_EQUAL_MESSAGE(0, state.decoded_manifest->manifest_component_id.len, "Invalid length of the manifest component ID");
+	TEST_ASSERT_NULL_MESSAGE(state.decoded_manifest->manifest_component_id.value, "Invalid value of the manifest component ID");
+	TEST_ASSERT_EQUAL_MESSAGE(0x10, state.decoded_manifest->sequence_number, "Incorrect manifest sequence number value");
+}
+
 void test_decode_manifest_invalid_input_bytes(void)
 {
 	int ret = SUIT_SUCCESS;
@@ -639,8 +744,8 @@ void test_decode_manifest_invalid_input_bytes(void)
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{
-			.envelope = cbor_envelope_with_6_components,
-			.envelope_size = sizeof(cbor_envelope_with_6_components),
+			.envelope = cbor_envelope_with_13_components,
+			.envelope_size = sizeof(cbor_envelope_with_13_components),
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{
@@ -649,8 +754,8 @@ void test_decode_manifest_invalid_input_bytes(void)
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{
-			.envelope = cbor_envelope_with_5_dependencies,
-			.envelope_size = sizeof(cbor_envelope_with_5_dependencies),
+			.envelope = cbor_envelope_with_8_dependencies,
+			.envelope_size = sizeof(cbor_envelope_with_8_dependencies),
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{

--- a/tests/unit/decoder/testcase.yaml
+++ b/tests/unit/decoder/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.decoder:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor suit-decoder

--- a/tests/unit/fetch_integrated_manifests/testcase.yaml
+++ b/tests/unit/fetch_integrated_manifests/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.fetch_integrated_manifests:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor integrated-manifest fetch

--- a/tests/unit/fetch_integrated_payload/testcase.yaml
+++ b/tests/unit/fetch_integrated_payload/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.fetch_integrated_payload:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor integrated-payload fetch

--- a/tests/unit/manifest/src/main.c
+++ b/tests/unit/manifest/src/main.c
@@ -169,19 +169,19 @@ void test_append_component_fill_array(void)
 	 * The remaining component IDs will be created by changing the length of the static string.
 	 */
 	static struct zcbor_string sample_component_0 = {
-		.value = "TEST_COMPONENT_0123456789abcdef67890abcd",
+		.value = "TEST_COMPONENT_0123456789abcdef67890abcd123456789abcdef67890abcd0123",
 		.len = sizeof("TEST_COMPONENT_0"),
 	};
 
 	/* Verify that the test boundaries can be reached. */
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd123456789abcdef67890abcd0123") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENTS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);
 
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd123456789abcdef67890abcd0123") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENT_PARAMS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);
@@ -474,19 +474,19 @@ void test_append_dependency_fill_array(void)
 	 * The remaining component IDs will be created by changing the length of the static string.
 	 */
 	static struct zcbor_string sample_component_0 = {
-		.value = "TEST_COMPONENT_0123456789abcdef67890abcd",
+		.value = "TEST_COMPONENT_0123456789abcdef67890abcd123456789abcdef67890abcd0123",
 		.len = sizeof("TEST_COMPONENT_0"),
 	};
 
 	/* Verify that the test boundaries can be reached. */
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd123456789abcdef67890abcd0123") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENTS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);
 
 	TEST_ASSERT_LESS_THAN_MESSAGE(
-		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd") - sizeof("TEST_COMPONENT_0"),
+		sizeof("TEST_COMPONENT_0123456789abcdef67890abcd123456789abcdef67890abcd0123") - sizeof("TEST_COMPONENT_0"),
 		SUIT_MAX_NUM_COMPONENT_PARAMS,
 		"Unable to reach maximum number of components. Please extend the component ID generator"
 	);

--- a/tests/unit/manifest/testcase.yaml
+++ b/tests/unit/manifest/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.manifest:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor suit-manifest

--- a/tests/unit/manifest_metadata/testcase.yaml
+++ b/tests/unit/manifest_metadata/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.menifest_metadata:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor suit-manifest-metadata

--- a/tests/unit/nested_seq/testcase.yaml
+++ b/tests/unit/nested_seq/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.nested_seq:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor run-command-sequence

--- a/tests/unit/seq_execution/testcase.yaml
+++ b/tests/unit/seq_execution/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.seq_execution:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor suit-schedule-execution

--- a/tests/unit/seq_validation/testcase.yaml
+++ b/tests/unit/seq_validation/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.seq_validation:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor suit-schedule-validation

--- a/tests/unit/try_each/testcase.yaml
+++ b/tests/unit/try_each/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.try_each:
-    platform_allow: native_posix native_posix_64 mps2_an521
+    platform_allow: native_posix native_posix/native/64 mps2_an521
     tags: suit-processor try-each


### PR DESCRIPTION
The SUIT processor must be able to fulfill the following scenario: Components:
1. APP_LOCAL_1
2. APP_LOCAL_2
3. APP_LOCAL_3
4. RAD_LOCAL_1
5. RAD_LOCAL_2
6. NORDIC_TOP
7. CAND_MFST
8. CACHE_POOL
9. dev-cfg [0]
10. dev-cfg [1]
11. dev-var

The following constrains were modified:
- integrated payload limit: 5 -> 6
- component limit: 5 -> 12
- dependency limit: 4 -> 7

The number of SUIT compoments was increased to 12, which means that it can fit all 11 required components with one slot of margin remaining.

The number of integrated payloads was increased to 6, which is enough to fit all manifest integrated payloads.

The number of dependencies was increased to 7, which is enough to process all 6 dependency manifests plus APP_recovery.