### PR TITLE
core: Pass AAD and IV as ciphertext data

### DIFF
--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -106,17 +106,8 @@ struct suit_report {
 struct suit_aes_kw_data {
 	/** @brief The key encryption key identifier. */
 	struct zcbor_string key_id;
-	/** @brief The Initialization Vector (IV) value.
-	 *
-	 * For some symmetric encryption algorithms, this may be referred to as a nonce.
-	 * The IV can be placed in the unprotected bucket, since for AE and AEAD algorithms,
-	 * modifying the IV will cause the decryption to fail.
-	 */
-	struct zcbor_string IV;
 	/** @brief The encrypted encryption key. */
 	struct zcbor_string ciphertext;
-	/** @brief A byte string to be used as the authenticated data structure. */
-	struct zcbor_string aad;
 };
 
 union suit_key_encryption_data {
@@ -127,6 +118,15 @@ union suit_key_encryption_data {
 struct suit_encryption_info {
 	/** @brief COSE algorithm ID for the content encryption method. */
 	enum suit_cose_alg enc_alg_id;
+	/** @brief The Initialization Vector (IV) value.
+	 *
+	 * For some symmetric encryption algorithms, this may be referred to as a nonce.
+	 * The IV can be placed in the unprotected bucket, since for AE and AEAD algorithms,
+	 * modifying the IV will cause the decryption to fail.
+	 */
+	struct zcbor_string IV;
+	/** @brief A byte string to be used as the authenticated data structure. */
+	struct zcbor_string aad;
 	/** @brief COSE algorithm ID for the key wrap method. */
 	enum suit_cose_alg kw_alg_id;
 	/** @brief Wrapped key. */

--- a/src/suit_directive.c
+++ b/src/suit_directive.c
@@ -40,12 +40,13 @@ static int decode_encryption_info(struct zcbor_string enc_info_bstr, struct suit
 	}
 
 	enc_info->enc_alg_id = suit_cose_aes256_gcm;
+	enc_info->IV = enc_info_cbor.COSE_Encrypt_unprotected.enc_header_map_IV;
+	enc_info->aad.value = suit_aad_aes256_gcm;
+	enc_info->aad.len = sizeof(suit_aad_aes256_gcm);
+
 	enc_info->kw_alg_id = suit_cose_aes256_kw;
 	enc_info->kw_key.aes.key_id = enc_info_cbor.COSE_Encrypt_recipients.COSE_recipients_protected_l_unprotected.rec_header_map_key_id;
-	enc_info->kw_key.aes.IV = enc_info_cbor.COSE_Encrypt_unprotected.enc_header_map_IV;
 	enc_info->kw_key.aes.ciphertext = enc_info_cbor.COSE_Encrypt_recipients.COSE_recipients_protected_l_ciphertext;
-	enc_info->kw_key.aes.aad.value = suit_aad_aes256_gcm;
-	enc_info->kw_key.aes.aad.len = sizeof(suit_aad_aes256_gcm);
 
 	return SUIT_SUCCESS;
 }


### PR DESCRIPTION
The AAD and IV are not specific to the key-wrap method. They are used to authenticate the encrypted payload.

Ref: NCSDK-28262