### PR TITLE
suit: Pass manifest component ID through platform API

### DIFF
--- a/include/suit_platform.h
+++ b/include/suit_platform.h
@@ -173,7 +173,7 @@ int suit_plat_authorize_component_id(struct zcbor_string *manifest_component_id,
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info);
+int suit_plat_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Fetch the given integrated payload into @p dst.
  *
@@ -182,7 +182,7 @@ int suit_plat_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struc
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info);
+int suit_plat_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Copy a payload from @p src_handle to @p dst_handle.
  *
@@ -191,7 +191,7 @@ int suit_plat_fetch_integrated(suit_component_t dst_handle, struct zcbor_string 
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_copy(suit_component_t dst_handle, suit_component_t src_handle, struct suit_encryption_info *enc_info);
+int suit_plat_copy(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Swap a payload from @p src_handle to @p dst_handle.
  *
@@ -200,7 +200,7 @@ int suit_plat_copy(suit_component_t dst_handle, suit_component_t src_handle, str
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_swap(suit_component_t dst_handle, suit_component_t src_handle, struct suit_encryption_info *enc_info);
+int suit_plat_swap(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Write a payload from @p content to @p dst_handle.
  *
@@ -209,7 +209,7 @@ int suit_plat_swap(suit_component_t dst_handle, suit_component_t src_handle, str
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_write(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info);
+int suit_plat_write(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Invoke the given image.
  *
@@ -296,7 +296,7 @@ int suit_plat_component_version_get(suit_component_t handle, int *version, size_
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info);
+int suit_plat_check_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given fetch of integrated payload can be performed.
  *
@@ -305,7 +305,7 @@ int suit_plat_check_fetch(suit_component_t dst_handle, struct zcbor_string *uri,
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info);
+int suit_plat_check_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given copy operation can be performed.
  *
@@ -314,7 +314,7 @@ int suit_plat_check_fetch_integrated(suit_component_t dst_handle, struct zcbor_s
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_copy(suit_component_t dst_handle, suit_component_t src_handle, struct suit_encryption_info *enc_info);
+int suit_plat_check_copy(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given swap operation can be performed.
  *
@@ -323,7 +323,7 @@ int suit_plat_check_copy(suit_component_t dst_handle, suit_component_t src_handl
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_swap(suit_component_t dst_handle, suit_component_t src_handle, struct suit_encryption_info *enc_info);
+int suit_plat_check_swap(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given invoke operation can be performed.
  *
@@ -332,7 +332,7 @@ int suit_plat_check_swap(suit_component_t dst_handle, suit_component_t src_handl
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_write(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info);
+int suit_plat_check_write(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given invoke operation can be performed.
  *

--- a/src/suit_directive.c
+++ b/src/suit_directive.c
@@ -624,26 +624,32 @@ int suit_directive_fetch(struct suit_processor_state *state, struct suit_manifes
 	if (!integrated) {
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT
 		if (state->dry_run != suit_bool_false) {
-			ret = suit_plat_check_fetch(component_params->component_handle, &component_params->uri, enc_info);
+			ret = suit_plat_check_fetch(component_params->component_handle, &component_params->uri,
+						    &seq_exec_state->manifest->manifest_component_id, enc_info);
 		} else {
 			component_modified(component_params);
-			ret = suit_plat_fetch(component_params->component_handle, &component_params->uri, enc_info);
+			ret = suit_plat_fetch(component_params->component_handle, &component_params->uri,
+					      &seq_exec_state->manifest->manifest_component_id, enc_info);
 		}
 #else /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 		component_modified(component_params);
-		ret = suit_plat_fetch(component_params->component_handle, &component_params->uri, enc_info);
+		ret = suit_plat_fetch(component_params->component_handle, &component_params->uri,
+				      &seq_exec_state->manifest->manifest_component_id, enc_info);
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 	} else {
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT
 		if (state->dry_run != suit_bool_false) {
-			ret = suit_plat_check_fetch_integrated(component_params->component_handle, &integrated_payload, enc_info);
+			ret = suit_plat_check_fetch_integrated(component_params->component_handle, &integrated_payload,
+							       &seq_exec_state->manifest->manifest_component_id, enc_info);
 		} else {
 			component_modified(component_params);
-			ret = suit_plat_fetch_integrated(component_params->component_handle, &integrated_payload, enc_info);
+			ret = suit_plat_fetch_integrated(component_params->component_handle, &integrated_payload,
+							 &seq_exec_state->manifest->manifest_component_id, enc_info);
 		}
 #else /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 		component_modified(component_params);
-		ret = suit_plat_fetch_integrated(component_params->component_handle, &integrated_payload, enc_info);
+		ret = suit_plat_fetch_integrated(component_params->component_handle, &integrated_payload,
+						 &seq_exec_state->manifest->manifest_component_id, enc_info);
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 	}
 
@@ -691,14 +697,19 @@ int suit_directive_copy(struct suit_processor_state *state, struct suit_manifest
 
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT
 	if (state->dry_run != suit_bool_false) {
-		return suit_plat_check_copy(dst_handle, src_handle, enc_info);
+		return suit_plat_check_copy(dst_handle, src_handle,
+					    &seq_exec_state->manifest->manifest_component_id,
+					    enc_info);
 	} else {
 		component_modified(component_params);
-		return suit_plat_copy(dst_handle, src_handle, enc_info);
+		return suit_plat_copy(dst_handle, src_handle,
+				      &seq_exec_state->manifest->manifest_component_id,
+				      enc_info);
 	}
 #else /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 	component_modified(component_params);
-	return suit_plat_copy(dst_handle, src_handle, enc_info);
+	return suit_plat_copy(dst_handle, src_handle,
+			      &seq_exec_state->manifest->manifest_component_id, enc_info);
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 }
 
@@ -706,6 +717,8 @@ int suit_directive_write(struct suit_processor_state *state, struct suit_manifes
 {
 	struct suit_encryption_info enc_info_struct = {0};
 	struct suit_encryption_info *enc_info = NULL;
+	struct suit_seq_exec_state *seq_exec_state;
+	int ret = SUIT_SUCCESS;
 
 	if ((state == NULL) || (component_params == NULL)) {
 		SUIT_ERR("Unable to execute write directive: invalid argument\r\n");
@@ -717,7 +730,7 @@ int suit_directive_write(struct suit_processor_state *state, struct suit_manifes
 	}
 
 	if (component_params->encryption_info_set) {
-		int ret = decode_encryption_info(component_params->encryption_info, &enc_info_struct);
+		ret = decode_encryption_info(component_params->encryption_info, &enc_info_struct);
 
 		if (ret != SUIT_SUCCESS) {
 			return ret;
@@ -726,16 +739,24 @@ int suit_directive_write(struct suit_processor_state *state, struct suit_manifes
 		enc_info = &enc_info_struct;
 	}
 
+	ret = suit_seq_exec_state_get(state, &seq_exec_state);
+	if (ret != SUIT_SUCCESS) {
+		return ret;
+	}
+
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT
 		if (state->dry_run != suit_bool_false) {
-			return suit_plat_check_write(component_params->component_handle, &component_params->content, enc_info);
+			return suit_plat_check_write(component_params->component_handle, &component_params->content,
+						     &seq_exec_state->manifest->manifest_component_id, enc_info);
 		} else {
 			component_modified(component_params);
-			return suit_plat_write(component_params->component_handle, &component_params->content, enc_info);
+			return suit_plat_write(component_params->component_handle, &component_params->content,
+					       &seq_exec_state->manifest->manifest_component_id, enc_info);
 		}
 #else /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 		component_modified(component_params);
-		return suit_plat_write(component_params->component_handle, &component_params->content, enc_info);
+		return suit_plat_write(component_params->component_handle, &component_params->content,
+				       &seq_exec_state->manifest->manifest_component_id, enc_info);
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,4 +10,4 @@ if [ -z "${ZEPHYR_BASE}" ]; then
        exit 1
 fi
 
-$ZEPHYR_BASE/scripts/twister -M -v -T . -W --platform native_posix --platform native_posix/native/64 $*
+$ZEPHYR_BASE/scripts/twister -M -v -T . -W --platform native_sim --platform native_sim/native/64 $*

--- a/tests/unit/bootstrap_envelope/testcase.yaml
+++ b/tests/unit/bootstrap_envelope/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.bootstrap_envelope:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor run-command-sequence

--- a/tests/unit/decoder/include/suit_platform_mock_ext.h
+++ b/tests/unit/decoder/include/suit_platform_mock_ext.h
@@ -170,45 +170,73 @@ int __authorize_sequence_num_callback(enum suit_command_sequence seq_name, struc
 }
 int __authorize_component_id_callback(struct zcbor_string *manifest_component_id, struct zcbor_string *component_id, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __check_fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_callback_queue); \
 	__cmock_suit_plat_check_fetch_AddCallback(__check_fetch_callback); \
-	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_callback_queue); \
 	__cmock_suit_plat_fetch_AddCallback(__fetch_callback); \
-	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_integrated_callback_queue); \
 	__cmock_suit_plat_check_fetch_integrated_AddCallback(__check_fetch_integrated_callback); \
-	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_integrated_callback_queue); \
 	__cmock_suit_plat_fetch_integrated_AddCallback(__fetch_integrated_callback); \
-	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_fetch_integrated_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
+
+#define __cmock_suit_plat_check_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __check_copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_copy_callback_queue); \
+	push_retval_arg(cmock_retval, __check_copy_callback_queue); \
+	__cmock_suit_plat_check_copy_AddCallback(__check_copy_callback); \
+	__cmock_suit_plat_check_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_copy_IgnoreArg_manifest_component_id(); \
+}
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
+
+#define __cmock_suit_plat_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __copy_callback_queue); \
+	push_retval_arg(cmock_retval, __copy_callback_queue); \
+	__cmock_suit_plat_copy_AddCallback(__copy_callback); \
+	__cmock_suit_plat_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_copy_IgnoreArg_manifest_component_id(); \
+}
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 
 #define __cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(seq_name, manifest_component_id, envelope_str, envelope_len, cmock_retval) { \
@@ -221,25 +249,29 @@ int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string
 }
 int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zcbor_string *manifest_component_id, const uint8_t *envelope_str, size_t envelope_len, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __check_write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_write_callback_queue); \
 	push_retval_arg(cmock_retval, __check_write_callback_queue); \
 	__cmock_suit_plat_check_write_AddCallback(__check_write_callback); \
-	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_write_IgnoreArg_content(); \
+	__cmock_suit_plat_check_write_IgnoreArg_manifest_component_id(); \
 }
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __write_callback_queue); \
 	push_retval_arg(cmock_retval, __write_callback_queue); \
 	__cmock_suit_plat_write_AddCallback(__write_callback); \
-	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_write_IgnoreArg_content(); \
+	__cmock_suit_plat_write_IgnoreArg_manifest_component_id(); \
 }
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 #define __cmock_suit_plat_authorize_process_dependency_ExpectComplexArgsAndReturn(parent_component_id, child_component_id, seq_name, cmock_retval) { \
 	extern complex_arg_q_t __dependency_seq_authorize_callback_queue; \

--- a/tests/unit/decoder/src/suit_platform_mock_ext.c
+++ b/tests/unit/decoder/src/suit_platform_mock_ext.c
@@ -102,31 +102,49 @@ int __authorize_component_id_callback(struct zcbor_string *manifest_component_id
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_callback_queue);
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__check_fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_callback_queue);
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_integrated_callback_queue);
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_integrated_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_integrated_callback_queue);
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_integrated_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__check_copy_callback_queue);
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__check_copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__check_copy_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__copy_callback_queue);
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__copy_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__sequence_completed_callback_queue);
@@ -137,16 +155,18 @@ int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zc
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_write_callback_queue);
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_write_callback_queue, content);
+	(void)assert_complex_arg(&__check_write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_write_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__write_callback_queue);
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__write_callback_queue, content);
+	(void)assert_complex_arg(&__write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__write_callback_queue, NULL);
 }
 

--- a/tests/unit/decoder/testcase.yaml
+++ b/tests/unit/decoder/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.decoder:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor suit-decoder

--- a/tests/unit/fetch_integrated_manifests/include/suit_platform_mock_ext.h
+++ b/tests/unit/fetch_integrated_manifests/include/suit_platform_mock_ext.h
@@ -170,46 +170,73 @@ int __authorize_sequence_num_callback(enum suit_command_sequence seq_name, struc
 }
 int __authorize_component_id_callback(struct zcbor_string *manifest_component_id, struct zcbor_string *component_id, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __check_fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_callback_queue); \
 	__cmock_suit_plat_check_fetch_AddCallback(__check_fetch_callback); \
-	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_callback_queue); \
 	__cmock_suit_plat_fetch_AddCallback(__fetch_callback); \
-	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_integrated_callback_queue); \
 	__cmock_suit_plat_check_fetch_integrated_AddCallback(__check_fetch_integrated_callback); \
-	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_integrated_callback_queue); \
 	__cmock_suit_plat_fetch_integrated_AddCallback(__fetch_integrated_callback); \
-	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_fetch_integrated_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
+#define __cmock_suit_plat_check_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __check_copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_copy_callback_queue); \
+	push_retval_arg(cmock_retval, __check_copy_callback_queue); \
+	__cmock_suit_plat_check_copy_AddCallback(__check_copy_callback); \
+	__cmock_suit_plat_check_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_copy_IgnoreArg_manifest_component_id(); \
+}
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
+
+#define __cmock_suit_plat_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __copy_callback_queue); \
+	push_retval_arg(cmock_retval, __copy_callback_queue); \
+	__cmock_suit_plat_copy_AddCallback(__copy_callback); \
+	__cmock_suit_plat_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_copy_IgnoreArg_manifest_component_id(); \
+}
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 #define __cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(seq_name, manifest_component_id, envelope_str, envelope_len, cmock_retval) { \
 	extern complex_arg_q_t __sequence_completed_callback_queue; \
@@ -221,25 +248,29 @@ int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string
 }
 int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zcbor_string *manifest_component_id, const uint8_t *envelope_str, size_t envelope_len, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __check_write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_write_callback_queue); \
 	push_retval_arg(cmock_retval, __check_write_callback_queue); \
 	__cmock_suit_plat_check_write_AddCallback(__check_write_callback); \
-	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_write_IgnoreArg_content(); \
+	__cmock_suit_plat_check_write_IgnoreArg_manifest_component_id(); \
 }
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __write_callback_queue); \
 	push_retval_arg(cmock_retval, __write_callback_queue); \
 	__cmock_suit_plat_write_AddCallback(__write_callback); \
-	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_write_IgnoreArg_content(); \
+	__cmock_suit_plat_write_IgnoreArg_manifest_component_id(); \
 }
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 #define __cmock_suit_plat_authorize_process_dependency_ExpectComplexArgsAndReturn(parent_component_id, child_component_id, seq_name, cmock_retval) { \
 	extern complex_arg_q_t __dependency_seq_authorize_callback_queue; \

--- a/tests/unit/fetch_integrated_manifests/src/main.c
+++ b/tests/unit/fetch_integrated_manifests/src/main.c
@@ -145,7 +145,7 @@ void test_suit_process_seq_dependency_resolution(void)
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 
 	/* Fetch the dependency manifest (radio) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute radio manifest */
 	radio_assert_envelope_integrity(false);
@@ -163,7 +163,7 @@ void test_suit_process_seq_dependency_resolution(void)
 	radio_assert_component_deletion();
 
 	/* Fetch the dependency manifest (application) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute application manifest */
 	app_assert_envelope_integrity(false);
@@ -206,7 +206,7 @@ void test_suit_process_seq_payload_fetch(void)
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 
 	/* Fetch the dependency manifest (radio) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute radio manifest */
 	radio_assert_envelope_integrity(false);
@@ -224,7 +224,7 @@ void test_suit_process_seq_payload_fetch(void)
 	radio_assert_component_deletion();
 
 	/* Fetch the dependency manifest (application) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute application manifest */
 	app_assert_envelope_integrity(false);
@@ -269,7 +269,7 @@ void test_suit_process_seq_candidate_verification(void)
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 
 	/* Fetch the dependency manifest (radio) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute radio manifest */
 	radio_assert_envelope_integrity(false);
@@ -287,7 +287,7 @@ void test_suit_process_seq_candidate_verification(void)
 	radio_assert_component_deletion();
 
 	/* Fetch the dependency manifest (application) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute application manifest */
 	app_assert_envelope_integrity(false);
@@ -330,7 +330,7 @@ void test_suit_process_seq_install(void)
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 
 	/* Fetch the dependency manifest (radio) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_radio_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute radio manifest */
 	radio_assert_envelope_integrity(false);
@@ -345,15 +345,15 @@ void test_suit_process_seq_install(void)
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_INSTALL sequence from the radio manifest */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, &exp_radio_fw_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, &exp_radio_fw_payload, &exp_radio_manifest_id, NULL, SUIT_SUCCESS);
 	__cmock_suit_plat_check_image_match_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, suit_cose_sha256, &exp_radio_image_digest, SUIT_SUCCESS);
-	__cmock_suit_plat_copy_ExpectAndReturn(radio_fw_component_handle, radio_fw_memptr_component_handle, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_copy_ExpectComplexArgsAndReturn(radio_fw_component_handle, radio_fw_memptr_component_handle, &exp_radio_manifest_id, NULL, SUIT_SUCCESS);
 	__cmock_suit_plat_check_image_match_ExpectComplexArgsAndReturn(radio_fw_component_handle, suit_cose_sha256, &exp_radio_image_digest, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_INSTALL, &exp_radio_manifest_id, exp_radio_envelope_payload.value, exp_radio_envelope_payload.len, SUIT_SUCCESS);
 	radio_assert_component_deletion();
 
 	/* Fetch the dependency manifest (application) */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(candidate_component_handle, &exp_app_envelope_payload, &exp_root_manifest_id, NULL, SUIT_SUCCESS);
 
 	/* Execute application manifest */
 	app_assert_envelope_integrity(false);
@@ -368,9 +368,9 @@ void test_suit_process_seq_install(void)
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_INSTALL sequence from the application manifest */
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, &exp_app_fw_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, &exp_app_fw_payload, &exp_app_manifest_id,  NULL, SUIT_SUCCESS);
 	__cmock_suit_plat_check_image_match_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, suit_cose_sha256, &exp_app_image_digest, SUIT_SUCCESS);
-	__cmock_suit_plat_copy_ExpectAndReturn(app_fw_component_handle, app_fw_memptr_component_handle, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_copy_ExpectComplexArgsAndReturn(app_fw_component_handle, app_fw_memptr_component_handle, &exp_app_manifest_id, NULL, SUIT_SUCCESS);
 	__cmock_suit_plat_check_image_match_ExpectComplexArgsAndReturn(app_fw_component_handle, suit_cose_sha256, &exp_app_image_digest, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_INSTALL, &exp_app_manifest_id, exp_app_envelope_payload.value, exp_app_envelope_payload.len, SUIT_SUCCESS);
 	app_assert_component_deletion();

--- a/tests/unit/fetch_integrated_manifests/src/suit_platform_mock_ext.c
+++ b/tests/unit/fetch_integrated_manifests/src/suit_platform_mock_ext.c
@@ -102,31 +102,49 @@ int __authorize_component_id_callback(struct zcbor_string *manifest_component_id
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_callback_queue);
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__check_fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_callback_queue);
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_integrated_callback_queue);
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_integrated_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_integrated_callback_queue);
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_integrated_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__check_copy_callback_queue);
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__check_copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__check_copy_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__copy_callback_queue);
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__copy_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__sequence_completed_callback_queue);
@@ -137,16 +155,18 @@ int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zc
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_write_callback_queue);
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_write_callback_queue, content);
+	(void)assert_complex_arg(&__check_write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_write_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__write_callback_queue);
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__write_callback_queue, content);
+	(void)assert_complex_arg(&__write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__write_callback_queue, NULL);
 }
 

--- a/tests/unit/fetch_integrated_manifests/testcase.yaml
+++ b/tests/unit/fetch_integrated_manifests/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.fetch_integrated_manifests:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor integrated-manifest fetch

--- a/tests/unit/fetch_integrated_payload/include/suit_platform_mock_ext.h
+++ b/tests/unit/fetch_integrated_payload/include/suit_platform_mock_ext.h
@@ -170,46 +170,73 @@ int __authorize_sequence_num_callback(enum suit_command_sequence seq_name, struc
 }
 int __authorize_component_id_callback(struct zcbor_string *manifest_component_id, struct zcbor_string *component_id, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __check_fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_callback_queue); \
 	__cmock_suit_plat_check_fetch_AddCallback(__check_fetch_callback); \
-	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_callback_queue); \
 	__cmock_suit_plat_fetch_AddCallback(__fetch_callback); \
-	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_integrated_callback_queue); \
 	__cmock_suit_plat_check_fetch_integrated_AddCallback(__check_fetch_integrated_callback); \
-	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_check_fetch_integrated_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_integrated_callback_queue); \
 	__cmock_suit_plat_fetch_integrated_AddCallback(__fetch_integrated_callback); \
-	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_fetch_integrated_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
+#define __cmock_suit_plat_check_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __check_copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_copy_callback_queue); \
+	push_retval_arg(cmock_retval, __check_copy_callback_queue); \
+	__cmock_suit_plat_check_copy_AddCallback(__check_copy_callback); \
+	__cmock_suit_plat_check_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_copy_IgnoreArg_manifest_component_id(); \
+}
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
+
+#define __cmock_suit_plat_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __copy_callback_queue); \
+	push_retval_arg(cmock_retval, __copy_callback_queue); \
+	__cmock_suit_plat_copy_AddCallback(__copy_callback); \
+	__cmock_suit_plat_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_copy_IgnoreArg_manifest_component_id(); \
+}
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 #define __cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(seq_name, manifest_component_id, envelope_str, envelope_len, cmock_retval) { \
 	extern complex_arg_q_t __sequence_completed_callback_queue; \
@@ -221,25 +248,29 @@ int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string
 }
 int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zcbor_string *manifest_component_id, const uint8_t *envelope_str, size_t envelope_len, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __check_write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_write_callback_queue); \
 	push_retval_arg(cmock_retval, __check_write_callback_queue); \
 	__cmock_suit_plat_check_write_AddCallback(__check_write_callback); \
-	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_write_IgnoreArg_content(); \
+	__cmock_suit_plat_check_write_IgnoreArg_manifest_component_id(); \
 }
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __write_callback_queue); \
 	push_retval_arg(cmock_retval, __write_callback_queue); \
 	__cmock_suit_plat_write_AddCallback(__write_callback); \
-	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_write_IgnoreArg_content(); \
+	__cmock_suit_plat_write_IgnoreArg_manifest_component_id(); \
 }
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 #define __cmock_suit_plat_authorize_process_dependency_ExpectComplexArgsAndReturn(parent_component_id, child_component_id, seq_name, cmock_retval) { \
 	extern complex_arg_q_t __dependency_seq_authorize_callback_queue; \

--- a/tests/unit/fetch_integrated_payload/src/main.c
+++ b/tests/unit/fetch_integrated_payload/src/main.c
@@ -289,7 +289,7 @@ void test_suit_process_seq_install(void)
 	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_cid_uuid, SUIT_SUCCESS);
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_image_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_image_payload, &exp_manifest_id, NULL, SUIT_SUCCESS);
 	__cmock_suit_plat_check_image_match_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, suit_cose_sha256, &exp_image_digest, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectAndReturn(SUIT_SEQ_INSTALL, &exp_manifest_id, manifest_buf, manifest_len, SUIT_SUCCESS);
 

--- a/tests/unit/fetch_integrated_payload/src/suit_platform_mock_ext.c
+++ b/tests/unit/fetch_integrated_payload/src/suit_platform_mock_ext.c
@@ -102,31 +102,49 @@ int __authorize_component_id_callback(struct zcbor_string *manifest_component_id
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_callback_queue);
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__check_fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_callback_queue);
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_integrated_callback_queue);
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_integrated_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_integrated_callback_queue);
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_integrated_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__check_copy_callback_queue);
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__check_copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__check_copy_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__copy_callback_queue);
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__copy_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__sequence_completed_callback_queue);
@@ -137,16 +155,18 @@ int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zc
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_write_callback_queue);
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_write_callback_queue, content);
+	(void)assert_complex_arg(&__check_write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_write_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__write_callback_queue);
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__write_callback_queue, content);
+	(void)assert_complex_arg(&__write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__write_callback_queue, NULL);
 }
 

--- a/tests/unit/fetch_integrated_payload/testcase.yaml
+++ b/tests/unit/fetch_integrated_payload/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.fetch_integrated_payload:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor integrated-payload fetch

--- a/tests/unit/manifest/testcase.yaml
+++ b/tests/unit/manifest/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.manifest:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor suit-manifest

--- a/tests/unit/manifest_metadata/testcase.yaml
+++ b/tests/unit/manifest_metadata/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.menifest_metadata:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor suit-manifest-metadata

--- a/tests/unit/nested_seq/testcase.yaml
+++ b/tests/unit/nested_seq/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.nested_seq:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor run-command-sequence

--- a/tests/unit/seq_execution/include/suit_platform_mock_ext.h
+++ b/tests/unit/seq_execution/include/suit_platform_mock_ext.h
@@ -170,45 +170,73 @@ int __authorize_sequence_num_callback(enum suit_command_sequence seq_name, struc
 }
 int __authorize_component_id_callback(struct zcbor_string *manifest_component_id, struct zcbor_string *component_id, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __check_fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_callback_queue); \
 	__cmock_suit_plat_check_fetch_AddCallback(__check_fetch_callback); \
-	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_callback_queue; \
 	push_complex_arg(uri, assert_zcbor_string, __fetch_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_callback_queue); \
 	__cmock_suit_plat_fetch_AddCallback(__fetch_callback); \
-	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_ExpectAndReturn(dst_handle, uri, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_IgnoreArg_uri(); \
+	__cmock_suit_plat_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __check_fetch_integrated_callback_queue); \
 	__cmock_suit_plat_check_fetch_integrated_AddCallback(__check_fetch_integrated_callback); \
-	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_check_fetch_IgnoreArg_manifest_component_id(); \
 }
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __fetch_integrated_callback_queue; \
 	push_complex_arg(payload, assert_zcbor_string, __fetch_integrated_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __fetch_integrated_callback_queue); \
 	push_retval_arg(cmock_retval, __fetch_integrated_callback_queue); \
 	__cmock_suit_plat_fetch_integrated_AddCallback(__fetch_integrated_callback); \
-	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, enc_info, cmock_retval); \
+	__cmock_suit_plat_fetch_integrated_ExpectAndReturn(dst_handle, payload, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_fetch_integrated_IgnoreArg_payload(); \
+	__cmock_suit_plat_fetch_integrated_IgnoreArg_manifest_component_id(); \
 }
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
+
+#define __cmock_suit_plat_check_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __check_copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_copy_callback_queue); \
+	push_retval_arg(cmock_retval, __check_copy_callback_queue); \
+	__cmock_suit_plat_check_copy_AddCallback(__check_copy_callback); \
+	__cmock_suit_plat_check_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_copy_IgnoreArg_manifest_component_id(); \
+}
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
+
+#define __cmock_suit_plat_copy_ExpectComplexArgsAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval) { \
+	extern complex_arg_q_t __copy_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __copy_callback_queue); \
+	push_retval_arg(cmock_retval, __copy_callback_queue); \
+	__cmock_suit_plat_copy_AddCallback(__copy_callback); \
+	__cmock_suit_plat_copy_ExpectAndReturn(dst_handle, src_handle, manifest_component_id, enc_info, cmock_retval); \
+	__cmock_suit_plat_copy_IgnoreArg_manifest_component_id(); \
+}
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 
 #define __cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(seq_name, manifest_component_id, envelope_str, envelope_len, cmock_retval) { \
@@ -221,25 +249,29 @@ int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string
 }
 int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zcbor_string *manifest_component_id, const uint8_t *envelope_str, size_t envelope_len, int cmock_num_calls);
 
-#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_check_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __check_write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __check_write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __check_write_callback_queue); \
 	push_retval_arg(cmock_retval, __check_write_callback_queue); \
 	__cmock_suit_plat_check_write_AddCallback(__check_write_callback); \
-	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_check_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_check_write_IgnoreArg_content(); \
+	__cmock_suit_plat_check_write_IgnoreArg_manifest_component_id(); \
 }
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
-#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, enc_info, cmock_retval) { \
+#define __cmock_suit_plat_write_ExpectComplexArgsAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval) { \
 	extern complex_arg_q_t __write_callback_queue; \
 	push_complex_arg(content, assert_zcbor_string, __write_callback_queue); \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __write_callback_queue); \
 	push_retval_arg(cmock_retval, __write_callback_queue); \
 	__cmock_suit_plat_write_AddCallback(__write_callback); \
-	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, enc_info, cmock_retval); \
+	__cmock_suit_plat_write_ExpectAndReturn(dst_handle, content, manifest_component_id, enc_info, cmock_retval); \
 	__cmock_suit_plat_write_IgnoreArg_content(); \
+	__cmock_suit_plat_write_IgnoreArg_manifest_component_id(); \
 }
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls);
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls);
 
 #define __cmock_suit_plat_authorize_process_dependency_ExpectComplexArgsAndReturn(parent_component_id, child_component_id, seq_name, cmock_retval) { \
 	extern complex_arg_q_t __dependency_seq_authorize_callback_queue; \

--- a/tests/unit/seq_execution/src/suit_condition_dependency_integrity.c
+++ b/tests/unit/seq_execution/src/suit_condition_dependency_integrity.c
@@ -150,7 +150,6 @@ static struct zcbor_string unknown_manifest_component_id = {
 	.len = 0,
 };
 
-
 static int execute_command_sequence(struct suit_processor_state *state, struct zcbor_string *cmd_seq_str)
 {
 	enum suit_command_sequence seq = SUIT_SEQ_PAYLOAD_FETCH;
@@ -485,7 +484,7 @@ void test_seq_execution_condition_dependency_integrity_integrity_lost_fetch(void
 		.len = strlen("http://example.com/app.bin"),
 	};
 
-	__cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_uri, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_uri, &unknown_manifest_component_id,  NULL, SUIT_SUCCESS);
 
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_dependency_components(&state, 1);
@@ -547,7 +546,7 @@ void test_seq_execution_condition_dependency_integrity_integrity_lost_fetch_inte
 		.len = sizeof("My application"),
 	};
 
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_payload, &unknown_manifest_component_id, NULL, SUIT_SUCCESS);
 
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_dependency_components(&state, 1);
@@ -604,7 +603,8 @@ void test_seq_execution_condition_dependency_integrity_integrity_lost_copy(void)
 	__cmock_suit_plat_release_component_handle_ExpectAndReturn(exp_component_id_handle, SUIT_SUCCESS);
 
 	uint32_t exp_src_handle = ASSIGNED_COMPONENT_HANDLE + 1;
-	__cmock_suit_plat_copy_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_src_handle, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_copy_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_src_handle, &unknown_manifest_component_id, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_copy_IgnoreArg_manifest_component_id();
 
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_dependency_components(&state, 2);
@@ -659,7 +659,7 @@ void test_seq_execution_condition_dependency_integrity_integrity_lost_write(void
 		.value = "test_data",
 		.len = strlen("test_data"),
 	};
-	__cmock_suit_plat_write_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_content, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_write_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_content, &unknown_manifest_component_id, NULL, SUIT_SUCCESS);
 
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_dependency_components(&state, 1);

--- a/tests/unit/seq_execution/src/suit_platform_mock_ext.c
+++ b/tests/unit/seq_execution/src/suit_platform_mock_ext.c
@@ -102,31 +102,49 @@ int __authorize_component_id_callback(struct zcbor_string *manifest_component_id
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_callback_queue);
-int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__check_fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_callback_queue);
-int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_callback(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_callback_queue, uri);
+	(void)assert_complex_arg(&__fetch_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_fetch_integrated_callback_queue);
-int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__check_fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_fetch_integrated_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__fetch_integrated_callback_queue);
-int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __fetch_integrated_callback(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__fetch_integrated_callback_queue, payload);
+	(void)assert_complex_arg(&__fetch_integrated_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__fetch_integrated_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__check_copy_callback_queue);
+int __check_copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__check_copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__check_copy_callback_queue, NULL);
+}
+
+COMPLEX_ARG_Q_DEFINE(__copy_callback_queue);
+int __copy_callback(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__copy_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__copy_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__sequence_completed_callback_queue);
@@ -137,16 +155,18 @@ int __sequence_completed_callback(enum suit_command_sequence seq_name, struct zc
 }
 
 COMPLEX_ARG_Q_DEFINE(__check_write_callback_queue);
-int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __check_write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__check_write_callback_queue, content);
+	(void)assert_complex_arg(&__check_write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__check_write_callback_queue, NULL);
 }
 
 COMPLEX_ARG_Q_DEFINE(__write_callback_queue);
-int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct suit_encryption_info *enc_info, int cmock_num_calls)
+int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info, int cmock_num_calls)
 {
 	(void)assert_complex_arg(&__write_callback_queue, content);
+	(void)assert_complex_arg(&__write_callback_queue, manifest_component_id);
 	return assert_complex_arg(&__write_callback_queue, NULL);
 }
 

--- a/tests/unit/seq_execution/src/test_directive_copy.c
+++ b/tests/unit/seq_execution/src/test_directive_copy.c
@@ -13,6 +13,11 @@
 
 extern struct suit_processor_state state;
 
+static struct zcbor_string unknown_manifest_component_id = {
+	.value = NULL,
+	.len = 0,
+};
+
 static int execute_command_sequence(struct suit_processor_state *state, struct zcbor_string *cmd_seq_str)
 {
 	enum suit_command_sequence seq = SUIT_SEQ_PAYLOAD_FETCH;
@@ -119,7 +124,9 @@ void test_seq_execution_copy_ok(void)
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_components(&state, 2);
 
-	__cmock_suit_plat_copy_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_src_handle, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_copy_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_src_handle,
+					       &unknown_manifest_component_id, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_copy_IgnoreArg_manifest_component_id();
 
 	int retval = execute_command_sequence(&state, &seq);
 

--- a/tests/unit/seq_execution/src/test_directive_fetch.c
+++ b/tests/unit/seq_execution/src/test_directive_fetch.c
@@ -13,6 +13,11 @@
 
 extern struct suit_processor_state state;
 
+static struct zcbor_string unknown_manifest_component_id = {
+	.value = NULL,
+	.len = 0,
+};
+
 static int execute_command_sequence(struct suit_processor_state *state, struct zcbor_string *cmd_seq_str)
 {
 	enum suit_command_sequence seq = SUIT_SEQ_PAYLOAD_FETCH;
@@ -73,7 +78,8 @@ void test_seq_execution_fetch_external_uri(void)
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_components(&state, 1);
 
-	__cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_uri, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_uri, &unknown_manifest_component_id, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_IgnoreArg_manifest_component_id();
 
 	int retval = execute_command_sequence(&state, &seq);
 
@@ -113,7 +119,8 @@ void test_seq_execution_fetch_internal_uri(void)
 	state.manifest_stack[0].integrated_payloads[0].key = exp_uri;
 	state.manifest_stack[0].integrated_payloads[0].payload = exp_payload;
 
-	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_payload, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_payload, &unknown_manifest_component_id, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_fetch_integrated_IgnoreArg_manifest_component_id();
 
 	int retval = execute_command_sequence(&state, &seq);
 

--- a/tests/unit/seq_execution/src/test_directive_write.c
+++ b/tests/unit/seq_execution/src/test_directive_write.c
@@ -13,6 +13,11 @@
 
 extern struct suit_processor_state state;
 
+static struct zcbor_string unknown_manifest_component_id = {
+	.value = NULL,
+	.len = 0,
+};
+
 static int execute_command_sequence(struct suit_processor_state *state, struct zcbor_string *cmd_seq_str)
 {
 	enum suit_command_sequence seq = SUIT_SEQ_PAYLOAD_FETCH;
@@ -71,7 +76,10 @@ void test_seq_execution_write_content(void)
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_components(&state, 1);
 
-	__cmock_suit_plat_write_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_content, NULL, SUIT_SUCCESS);
+	__cmock_suit_plat_write_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_content,
+							   &unknown_manifest_component_id, NULL,
+							   SUIT_SUCCESS);
+	__cmock_suit_plat_write_IgnoreArg_manifest_component_id();
 
 	int retval = execute_command_sequence(&state, &seq);
 

--- a/tests/unit/seq_execution/testcase.yaml
+++ b/tests/unit/seq_execution/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.seq_execution:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor suit-schedule-execution

--- a/tests/unit/seq_validation/testcase.yaml
+++ b/tests/unit/seq_validation/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.seq_validation:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor suit-schedule-validation

--- a/tests/unit/try_each/testcase.yaml
+++ b/tests/unit/try_each/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   suit-processor.unit.try_each:
-    platform_allow: native_posix native_posix/native/64 mps2_an521
+    platform_allow: native_sim native_sim/native/64 mps2_an521
     tags: suit-processor try-each


### PR DESCRIPTION
This commit adds the additional manifest component ID to multiple functions in the platform API. This is an enabler for such functionalities as validating the KEY ID for decryption.

Ref: NCSDK-28626