### PR TITLE
NCSDK-31343: Pass manifest class id while overriting image size

### DIFF
--- a/include/suit.h
+++ b/include/suit.h
@@ -32,7 +32,8 @@ int suit_processor_init(void);
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_process_sequence(const uint8_t *envelope_str, size_t envelope_len, enum suit_command_sequence seq_name);
+int suit_process_sequence(const uint8_t *envelope_str, size_t envelope_len,
+			  enum suit_command_sequence seq_name);
 
 /** Extract metadata from the given envelope.
  *
@@ -42,26 +43,34 @@ int suit_process_sequence(const uint8_t *envelope_str, size_t envelope_len, enum
  *           - semantic version and version length
  *           - digest and digest algorithm ID
  *           - sequence number
- *          The metadata sets that should not be returned can be skipped by passing the NULL pointer.
+ *          The metadata sets that should not be returned can be skipped by passing the NULL
+ *          pointer.
  *
  * @note The output structures will be set to point to the correct places within the input envelope.
  *
  * @param[in]     envelope_str           Reference to the input envelope to be parsed.
  * @param[in]     envelope_len           Length of the input envelope.
- * @param[in]     authenticate           Boolean flag, indicating if the input manifest should be authenticated.
- * @param[out]    manifest_component_id  Pointer to the structure in which the manifest component ID value will
- *                                       be stored.
- * @param[out]    version                Pointer to an array that will be filled with the manifest version (semantic)
- *                                       value.
+ * @param[in]     authenticate           Boolean flag, indicating if the input manifest should be
+ *                                       authenticated.
+ * @param[out]    manifest_component_id  Pointer to the structure in which the manifest component ID
+ *                                       value will be stored.
+ * @param[out]    version                Pointer to an array that will be filled with the manifest
+ *                                       version (semantic) value.
  * @param[inout]  version_len            As input - maximum length of the version array.
  *                                       As output - length of the manifest version.
- * @param[out]    digest                 Pointer to the structure in which the manifest digest value will be stored.
+ * @param[out]    digest                 Pointer to the structure in which the manifest digest value
+ *                                       will be stored.
  * @param[out]    alg                    Algorithm, used to calculate the digest.
- * @param[out]    seq_num                Pointer to the structure in which the manifest sequence number will be stored.
+ * @param[out]    seq_num                Pointer to the structure in which the manifest sequence
+ *                                       number will be stored.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_processor_get_manifest_metadata(const uint8_t *envelope_str, size_t envelope_len, bool authenticate, struct zcbor_string *manifest_component_id, int *version, size_t *version_len, struct zcbor_string *digest, enum suit_cose_alg *alg, unsigned int *seq_num);
+int suit_processor_get_manifest_metadata(const uint8_t *envelope_str, size_t envelope_len,
+					 bool authenticate,
+					 struct zcbor_string *manifest_component_id, int *version,
+					 size_t *version_len, struct zcbor_string *digest,
+					 enum suit_cose_alg *alg, unsigned int *seq_num);
 
 #ifdef __cplusplus
 }

--- a/include/suit_condition.h
+++ b/include/suit_condition.h
@@ -15,43 +15,43 @@ extern "C" {
 
 /** Check a vendor ID based on the configured parameters. */
 int suit_condition_vendor_identifier(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+				     struct suit_manifest_params *component_params);
 
 /** Check a class ID based on the configured parameters. */
 int suit_condition_class_identifier(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+				    struct suit_manifest_params *component_params);
 
 /** Check a device ID based on the configured parameters. */
 int suit_condition_device_identifier(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+				     struct suit_manifest_params *component_params);
 
 /** Check an image digest/size based on the configured parameters. */
 int suit_condition_image_match(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+			       struct suit_manifest_params *component_params);
 
 /** Check a component slot based on the configured parameters. */
 int suit_condition_component_slot(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+				  struct suit_manifest_params *component_params);
 
 /** Check if the component content matches the configured parameter. */
 int suit_condition_check_content(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+				 struct suit_manifest_params *component_params);
 
 /** Unconditionally fail. */
 int suit_condition_abort(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+			 struct suit_manifest_params *component_params);
 
 /** Check a manifest component integrity and signature. */
 int suit_condition_dependency_integrity(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+					struct suit_manifest_params *component_params);
 
 /** Check if component is a dependency manifest component. */
 int suit_condition_is_dependency(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+				 struct suit_manifest_params *component_params);
 
 /** Check if component version matches the range configured by the parameter. */
 int suit_condition_version(struct suit_processor_state *state,
-		struct suit_manifest_params *component_params);
+			   struct suit_manifest_params *component_params);
 
 #ifdef __cplusplus
 }

--- a/include/suit_decoder.h
+++ b/include/suit_decoder.h
@@ -15,7 +15,8 @@ extern "C" {
 
 /** @brief Initialize the decoder context.
  *
- * @details The decoder output will be incrementally stored inside the provided manifest context structure.
+ * @details The decoder output will be incrementally stored inside the provided manifest context
+ *          structure.
  *
  * @param[in] state     Manifest decoder state to use.
  * @param[in] manifest  Manifest structure to use during decoder operation.
@@ -37,16 +38,18 @@ int suit_decoder_init(struct suit_decoder_state *state, struct suit_manifest_sta
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_decoder_decode_envelope(struct suit_decoder_state *state, const uint8_t *envelope_str, size_t envelope_len);
+int suit_decoder_decode_envelope(struct suit_decoder_state *state, const uint8_t *envelope_str,
+				 size_t envelope_len);
 
 /** @brief Verify the SUIT manifest digest.
  *
- * @details In this step the manifest payload will be checked against the digest, stored inside the authentication wrapper.
- *          This step does not decode the manifest payload contents.
+ * @details In this step the manifest payload will be checked against the digest, stored inside the
+ *          authentication wrapper. This step does not decode the manifest payload contents.
  *
  * @note This function checks the integrity of the manifest structure.
  *       It does not authenticate the manifest.
- *       The manifest authentication is postponed, since it requires the manifest component ID to be decoded.
+ *       The manifest authentication is postponed, since it requires the manifest component ID to be
+ *       decoded.
  *
  * @param[in] state  Manifest decoder state to use.
  *
@@ -57,9 +60,9 @@ int suit_decoder_check_manifest_digest(struct suit_decoder_state *state);
 /** @brief Decode the SUIT manifest.
  *
  * @details In this step the manifest structure, fetched from the decoded envelope will be parsed.
- *          The internal ZCBOR structure will be filled with pointers and the input data will be validated
- *          against the CDDL by the ZCBOR library.
- *          Due to the nested character of the sequences, only the first level of nesting is checked by this function.
+ *          The internal ZCBOR structure will be filled with pointers and the input data will be
+ *          validated against the CDDL by the ZCBOR library. Due to the nested character of
+ *          the sequences, only the first level of nesting is checked by this function.
  *
  * @note This function does not authenticate the manifest.
  *
@@ -72,9 +75,9 @@ int suit_decoder_decode_manifest(struct suit_decoder_state *state);
 /** @brief Authenticate the SUIT manifest.
  *
  * @details In this step the manifest digest will be checked against all of the signatures present
- *          inside the authentication wrappers.
- *          If the envelope does not contain signatures, the @p suit_plat_authorize_unsigned_manifest
- *          platform API will be used to authorize the manifest.
+ *          inside the authentication wrappers. If the envelope does not contain signatures, the
+ *          @p suit_plat_authorize_unsigned_manifest platform API will be used to authorize
+ *          the manifest.
  *
  * @note Delegation chains are not supported.
  *

--- a/include/suit_directive.h
+++ b/include/suit_directive.h
@@ -15,45 +15,61 @@ extern "C" {
 #endif /* __cplusplus */
 
 /** Set the current component indices. This decides which component(s)
- *  are affected by subsequent commands. */
-int suit_directive_set_current_components(struct suit_processor_state *state, struct IndexArg_r *index_arg);
+ *  are affected by subsequent commands.
+ */
+int suit_directive_set_current_components(struct suit_processor_state *state,
+					  struct IndexArg_r *index_arg);
 
-/** suit-directive-try-each */
+/** Execute list of sequences, one-by-one, until one of them succeeds.
+ *  Execution of the next sequence is possible only if the previous sequence
+ *  ends with @p suit-condition-failure and the @p soft-failure parameter is set.
+ */
 int suit_directive_try_each(struct suit_processor_state *state,
-		struct SUIT_Directive_Try_Each_Argument *try_each_arg,
-		bool validate);
+			    struct SUIT_Directive_Try_Each_Argument *try_each_arg, bool validate);
 
-/** suit-directive-run-sequence */
+/** Execute sequence of commands. */
 int suit_directive_run_sequence(struct suit_processor_state *state,
-		struct zcbor_string *command_sequence);
+				struct zcbor_string *command_sequence);
 
 /** Copy the parameters in @p new_parameters (that are set) into the parameter
- *  list of the current component(s). */
-int suit_directive_override_parameters(struct suit_processor_state *state,
-		struct suit_directive_override_parameters_m_l_map_SUIT_Parameters_m *params, uint_fast32_t param_count);
+ *  list of the current component(s).
+ */
+int suit_directive_override_parameters(
+	struct suit_processor_state *state,
+	struct suit_directive_override_parameters_m_l_map_SUIT_Parameters_m *params,
+	uint_fast32_t param_count);
 
 /** Fetch a payload based on the configured parameters. */
-int suit_directive_fetch(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+int suit_directive_fetch(struct suit_processor_state *state,
+			 struct suit_manifest_params *component_params);
 
 /** Copy a payload based on the configured parameters. */
-int suit_directive_copy(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+int suit_directive_copy(struct suit_processor_state *state,
+			struct suit_manifest_params *component_params);
 
 /** Write a small block of data to component */
-int suit_directive_write(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+int suit_directive_write(struct suit_processor_state *state,
+			 struct suit_manifest_params *component_params);
 
 /** Swap a payload based on the configured parameters. */
-int suit_directive_swap(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+int suit_directive_swap(struct suit_processor_state *state,
+			struct suit_manifest_params *component_params);
 
 /** Invoke/boot a component based on the configured parameters. */
-int suit_directive_invoke(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+int suit_directive_invoke(struct suit_processor_state *state,
+			  struct suit_manifest_params *component_params);
 
-/** Set the value of the parameters in @p param into the parameter list of the current component if its value is not set. */
-int suit_directive_set_parameters(struct suit_processor_state *state,
-		struct suit_directive_set_parameters_m_l_map_SUIT_Parameters_m *params, uint_fast32_t param_count,
-		struct suit_manifest_params *component_params);
+/** Set the value of the parameters in @p param into the parameter list of the current component if
+ *  its value is not set.
+ */
+int suit_directive_set_parameters(
+	struct suit_processor_state *state,
+	struct suit_directive_set_parameters_m_l_map_SUIT_Parameters_m *params,
+	uint_fast32_t param_count, struct suit_manifest_params *component_params);
 
 /** Process the current sequence of the dependency manifest. */
-int suit_directive_process_dependency(struct suit_processor_state *state, struct suit_manifest_params *component_params);
+int suit_directive_process_dependency(struct suit_processor_state *state,
+				      struct suit_manifest_params *component_params);
 
 #ifdef __cplusplus
 }

--- a/include/suit_manifest.h
+++ b/include/suit_manifest.h
@@ -29,12 +29,13 @@ int suit_manifest_params_init(struct suit_manifest_params *params, size_t count)
  *
  * @param[in] manifest      Manifest structure to modify.
  * @param[in] component_id  ZCBOR string holding the component ID.
- * @param[in] prefix        ZCBOR string holding the prefix to be used within the context of this manifest.
- *                          Currently only an empty prefix is supported.
+ * @param[in] prefix        ZCBOR string holding the prefix to be used within the context of this
+ *                          manifest. Currently only an empty prefix is supported.
  *
  * @returns SUIT_SUCCESS if the dependency component was appended, error code otherwise.
  */
-int suit_manifest_append_dependency(struct suit_manifest_state *manifest, struct zcbor_string *component_id, struct zcbor_string *prefix);
+int suit_manifest_append_dependency(struct suit_manifest_state *manifest,
+				    struct zcbor_string *component_id, struct zcbor_string *prefix);
 
 /** @brief Append a reference to a regular component to the manifest structure.
  *
@@ -46,7 +47,8 @@ int suit_manifest_append_dependency(struct suit_manifest_state *manifest, struct
  *
  * @returns SUIT_SUCCESS if the component was appended, error code otherwise.
  */
-int suit_manifest_append_component(struct suit_manifest_state *manifest, struct zcbor_string *component_id);
+int suit_manifest_append_component(struct suit_manifest_state *manifest,
+				   struct zcbor_string *component_id);
 
 /** @brief Release all components, referenced by the manifest and reset the structure contents.
  *
@@ -59,15 +61,18 @@ int suit_manifest_append_component(struct suit_manifest_state *manifest, struct 
  */
 int suit_manifest_release(struct suit_manifest_state *manifest);
 
-/** @brief Get the structure with SUIT component parameters for a given component index for a given manifest.
+/** @brief Get the structure with SUIT component parameters for a given component index for a given
+ *         manifest.
  *
  * @param[in]  manifest       Manifest structure, defining the context for the component index.
  * @param[in]  component_idx  Component index in the manifest.
  * @param[out] params         Reference to the structure with SUIT component parameters values.
  *
- * @returns SUIT_SUCCESS if the component was found and the structure was returned, error code otherwise.
+ * @returns SUIT_SUCCESS if the component was found and the structure was returned, error code
+ *                       otherwise.
  */
-int suit_manifest_get_component_params(struct suit_manifest_state *manifest, size_t component_idx, struct suit_manifest_params **params);
+int suit_manifest_get_component_params(struct suit_manifest_state *manifest, size_t component_idx,
+				       struct suit_manifest_params **params);
 
 /** @brief Get the reference to the given command sequence for a given manifest.
  *
@@ -77,10 +82,13 @@ int suit_manifest_get_component_params(struct suit_manifest_state *manifest, siz
  * @param[in]  seq_name  Name of the command sequence to return.
  * @param[out] payload   Reference to the pointer to ZCBOR string holding the sequence.
  *
- * @returns SUIT_SUCCESS if a valid, authenticated sequence was found, SUIT_ERR_UNAVAILABLE_COMMAND_SEQ if the sequence is not available,
+ * @returns SUIT_SUCCESS if a valid, authenticated sequence was found,
+ *                       SUIT_ERR_UNAVAILABLE_COMMAND_SEQ if the sequence is not available,
  *                       error code otherwise.
  */
-int suit_manifest_get_command_seq(struct suit_manifest_state *manifest, enum suit_command_sequence seq_name, struct zcbor_string **sequence);
+int suit_manifest_get_command_seq(struct suit_manifest_state *manifest,
+				  enum suit_command_sequence seq_name,
+				  struct zcbor_string **sequence);
 
 /** @brief Get the reference to an integrated payload with a given URI for a given manifest.
  *
@@ -88,9 +96,11 @@ int suit_manifest_get_command_seq(struct suit_manifest_state *manifest, enum sui
  * @param[in]  uri       URI of the integrated payload to find.
  * @param[out] payload   Reference to the ZCBOR string holding the integrated payload.
  *
- * @returns SUIT_SUCCESS if the integrated payload was found and the structure was returned, error code otherwise.
+ * @returns SUIT_SUCCESS if the integrated payload was found and the structure was returned, error
+ *                       code otherwise.
  */
-int suit_manifest_get_integrated_payload(struct suit_manifest_state *manifest, struct zcbor_string *uri, struct zcbor_string *payload);
+int suit_manifest_get_integrated_payload(struct suit_manifest_state *manifest,
+					 struct zcbor_string *uri, struct zcbor_string *payload);
 
 #ifdef __cplusplus
 }

--- a/include/suit_platform.h
+++ b/include/suit_platform.h
@@ -38,14 +38,13 @@ extern "C" {
  *
  * @returns SUIT_SUCCESS if the digest matches, error code otherwise.
  */
-int suit_plat_check_digest(enum suit_cose_alg alg_id,
-		struct zcbor_string *digest,
-		struct zcbor_string *payload);
+int suit_plat_check_digest(enum suit_cose_alg alg_id, struct zcbor_string *digest,
+			   struct zcbor_string *payload);
 
 /** @brief Authenticate the given manifest against the given signature.
  *
- * @param[in] manifest_component_id  The manifest component ID, identifying
- *                                   the type of manifest in the system.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
  * @param[in] alg_id                 The signature verification algorithm to use.
  * @param[in] key_id                 The key to check the signature with.
  * @param[in] signature              The signature to check.
@@ -54,13 +53,13 @@ int suit_plat_check_digest(enum suit_cose_alg alg_id,
  * @returns SUIT_SUCCESS if the signature is correct, error code otherwise.
  */
 int suit_plat_authenticate_manifest(struct zcbor_string *manifest_component_id,
-		enum suit_cose_alg alg_id, struct zcbor_string *key_id,
-		struct zcbor_string *signature, struct zcbor_string *data);
+				    enum suit_cose_alg alg_id, struct zcbor_string *key_id,
+				    struct zcbor_string *signature, struct zcbor_string *data);
 
 /** @brief Check that the provided manifest is allowed to be unsigned.
  *
- * @param[in] manifest_component_id  The manifest component ID, identifying
- *                                   the type of manifest in the system.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
  *
  * @returns SUIT_SUCCESS if the manifest can be processed, error code otherwise.
  */
@@ -69,19 +68,18 @@ int suit_plat_authorize_unsigned_manifest(struct zcbor_string *manifest_componen
 /** @brief Check that the given component ID exists, is valid, and is authorized.
  *         If so, create and return a component handle for it.
  *
- * @param[in]  component_id      The CBOR-encoded component identifier.
- * @param[in]  dependency        True if a component is a dependency component.
- * @param[out] component_handle  A reference for use with other functions in
- *                               this API, instead of always passing the
- *                               @p parts.
+ * @param[in]  component_id  The CBOR-encoded component identifier.
+ * @param[in]  dependency    True if a component is a dependency component.
+ * @param[out] handle        A reference for use with other functions in this API.
  *
  * @returns SUIT_SUCCESS if the component handle was created, error code otherwise.
  */
-int suit_plat_create_component_handle(struct zcbor_string *component_id, bool dependency, suit_component_t *handle);
+int suit_plat_create_component_handle(struct zcbor_string *component_id, bool dependency,
+				      suit_component_t *handle);
 
 /** @brief Release loaded component properties and handles assigned to them.
  *
- * @param[in] component_handle  The platform-specific component handle value.
+ * @param[in] handle  The platform-specific component handle value.
  *
  * @returns SUIT_SUCCESS if the component handle was released, error code otherwise.
  */
@@ -89,14 +87,14 @@ int suit_plat_release_component_handle(suit_component_t handle);
 
 /** @brief Check the provided payload against the provided digest.
  *
- * @param[in] handle      A reference to the checked component.
- * @param[in] alg_id      The digest verification algorithm to use.
- * @param[in] digest      Expected diest value.
+ * @param[in] handle  A reference to the checked component.
+ * @param[in] alg_id  The digest verification algorithm to use.
+ * @param[in] digest  Expected diest value.
  *
  * @returns SUIT_SUCCESS if the image digest matches, error code otherwise.
  */
-int suit_plat_check_image_match(suit_component_t handle,
-		enum suit_cose_alg alg_id, struct zcbor_string *digest);
+int suit_plat_check_image_match(suit_component_t handle, enum suit_cose_alg alg_id,
+				struct zcbor_string *digest);
 
 /** @brief Check the provided payload against the component value.
  *
@@ -145,76 +143,107 @@ int suit_plat_check_cid(suit_component_t handle, struct zcbor_string *cid_uuid);
  */
 int suit_plat_check_did(suit_component_t handle, struct zcbor_string *did_uuid);
 
-/** @brief Check that the provided sequence number for a given manifest is recent enough.
+/** @brief Check that the provided sequence number for a given manifest is
+ *         recent enough.
  *
  * @param[in] seq_name               The currently processed SUIT manifest sequence.
- * @param[in] manifest_component_id  The manifest component ID, identifying
- *                                   the type of manifest in the system.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
  * @param[in] seq_num                The manifest sequence number value.
  *
- * @returns SUIT_SUCCESS if the sequence is allowed to be executed with a given sequence number, error code otherwise.
+ * @returns SUIT_SUCCESS if the sequence is allowed to be executed with a given sequence number,
+ *                       error code otherwise.
  */
-int suit_plat_authorize_sequence_num(enum suit_command_sequence seq_name, struct zcbor_string *manifest_component_id, unsigned int seq_num);
+int suit_plat_authorize_sequence_num(enum suit_command_sequence seq_name,
+				     struct zcbor_string *manifest_component_id,
+				     unsigned int seq_num);
 
 /** Check that the provided component ID is supported by the given manifest.
  *
- * @param[in] manifest_component_id  The manifest component ID, identifying
- *                                   the type of manifest in the system.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
  * @param[in] component_id           The CBOR-encoded component identifier to verify.
  *
  * @returns SUIT_SUCCESS if the component ID is allowed, error code otherwise.
  */
-int suit_plat_authorize_component_id(struct zcbor_string *manifest_component_id, struct zcbor_string *component_id);
+int suit_plat_authorize_component_id(struct zcbor_string *manifest_component_id,
+				     struct zcbor_string *component_id);
 
-/** @brief Fetch the payload from the given @p uri into @p dst.
+/** @brief Fetch the payload from the given @p uri into @p dst_handle.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] uri         A reference to the buffer, containing the URI to be fetched.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] uri                    A reference to the buffer, containing the URI to be fetched.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_fetch(suit_component_t dst_handle, struct zcbor_string *uri,
+		    struct zcbor_string *manifest_component_id,
+		    struct suit_encryption_info *enc_info);
 
-/** @brief Fetch the given integrated payload into @p dst.
+/** @brief Fetch the given integrated payload into @p dst_handle.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] payload     A reference to the buffer, describing the fetched content.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] payload                A reference to the buffer, describing the URI to be fetched.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload,
+			       struct zcbor_string *manifest_component_id,
+			       struct suit_encryption_info *enc_info);
 
 /** @brief Copy a payload from @p src_handle to @p dst_handle.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] src_handle  A reference to the source component.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] src_handle             A reference to the source component.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_copy(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_copy(suit_component_t dst_handle, suit_component_t src_handle,
+		   struct zcbor_string *manifest_component_id,
+		   struct suit_encryption_info *enc_info);
 
 /** @brief Swap a payload from @p src_handle to @p dst_handle.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] src_handle  A reference to the source component.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] src_handle             A reference to the source component.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_swap(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_swap(suit_component_t dst_handle, suit_component_t src_handle,
+		   struct zcbor_string *manifest_component_id,
+		   struct suit_encryption_info *enc_info);
 
 /** @brief Write a payload from @p content to @p dst_handle.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] content     A reference to the buffer, describing the content.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] content                A reference to the buffer, describing the content.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_write(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_write(suit_component_t dst_handle, struct zcbor_string *content,
+		    struct zcbor_string *manifest_component_id,
+		    struct suit_encryption_info *enc_info);
 
 /** @brief Invoke the given image.
  *
  * @param[in] image_handle  A reference to the invoked component.
- * @param[in] invoke_args   A reference to the buffer with platform-specific invoke arguments.
+ * @param[in] invoke_args   A reference to the buffer with platform-specific
+ *                          invoke arguments.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
@@ -234,14 +263,16 @@ int suit_plat_report(unsigned int rep_policy, struct suit_report *report);
 /** @brief A callback function, informing about the sequence completion.
  *
  * @param[in] seq_name               The finished SUIT manifest sequence.
- * @param[in] manifest_component_id  The manifest component ID, identifying
- *                                   the type of manifest in the system.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
  * @param[in] envelope_str           A reference to the SUIT envelope that was processed.
  * @param[in] envelope_len           The length of the processed envelope.
  *
  * @returns SUIT_SUCCESS if the callback succeeds, error code otherwise.
  */
-int suit_plat_sequence_completed(enum suit_command_sequence seq_name, struct zcbor_string *manifest_component_id, const uint8_t *envelope_str, size_t envelope_len);
+int suit_plat_sequence_completed(enum suit_command_sequence seq_name,
+				 struct zcbor_string *manifest_component_id,
+				 const uint8_t *envelope_str, size_t envelope_len);
 
 /** @brief Return a pointer to the SUIT envelope, stored inside the component.
  *
@@ -251,23 +282,28 @@ int suit_plat_sequence_completed(enum suit_command_sequence seq_name, struct zcb
  *
  * @returns SUIT_SUCCESS if the manifest was returned, error code otherwise.
  */
-int suit_plat_retrieve_manifest(suit_component_t component_handle, const uint8_t **envelope_str, size_t *envelope_len);
+int suit_plat_retrieve_manifest(suit_component_t component_handle, const uint8_t **envelope_str,
+				size_t *envelope_len);
 
-/** @brief Set the current image size value, stored inside the platform component metadata.
+/** @brief Set the current image size value, stored inside the platform
+ * component metadata.
  *
  * @param[in] handle                 A reference to the component, describing the SUIT envelope.
  * @param[in] size                   The component size, set by the manifest command.
- * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest in the system.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
  *
  * @returns SUIT_SUCCESS if the size was set, error code otherwise.
  */
-int suit_plat_override_image_size(suit_component_t handle, size_t size, struct zcbor_string *manifest_component_id);
+int suit_plat_override_image_size(suit_component_t handle, size_t size,
+				  struct zcbor_string *manifest_component_id);
 
 /** @brief Authorize execution of the given sequence of the dependency manifest.
  *
- * @details This function allow to restrict different manifest topologies, depending on the execution context.
- *          For example, it may be allowed to include a manifest as dependency for the update procedure, but prohibited
- *          to boot it's components.
+ * @details This function allow to restrict different manifest topologies,
+ *          depending on the execution context.
+ *          For example, it may be allowed to include a manifest as dependency for the update
+ *          procedure, but prohibited to boot it's components.
  *
  * @param[in]  parent_component_id  Parent manifest component ID.
  * @param[in]  child_component_id   Child manifest component ID.
@@ -275,13 +311,15 @@ int suit_plat_override_image_size(suit_component_t handle, size_t size, struct z
  *
  * @returns SUIT_SUCCESS if the manifest was returned, error code otherwise.
  */
-int suit_plat_authorize_process_dependency(struct zcbor_string *parent_component_id, struct zcbor_string *child_component_id, enum suit_command_sequence seq_name);
+int suit_plat_authorize_process_dependency(struct zcbor_string *parent_component_id,
+					   struct zcbor_string *child_component_id,
+					   enum suit_command_sequence seq_name);
 
 /** @brief Read the current version of the component.
  *
  * @param[in]     handle       A reference to the component.
- * @param[out]    version      Pointer to an array that should be filled with the manifest version (semantic)
- *                             value.
+ * @param[out]    version      Pointer to an array that should be filled with the manifest version
+ *                             (semantic) value.
  * @param[inout]  version_len  As input - maximum length of the version array.
  *                             As output - length of the manifest version.
  *
@@ -292,48 +330,73 @@ int suit_plat_component_version_get(suit_component_t handle, int *version, size_
 #ifdef SUIT_PLATFORM_DRY_RUN_SUPPORT
 /** @brief Check that the given fetch operation can be performed.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] uri         A reference to the buffer, containing the URI to be fetched.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] uri                    A reference to the buffer, containing the URI to be fetched.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_fetch(suit_component_t dst_handle, struct zcbor_string *uri, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_check_fetch(suit_component_t dst_handle, struct zcbor_string *uri,
+			  struct zcbor_string *manifest_component_id,
+			  struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given fetch of integrated payload can be performed.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] payload     A reference to the buffer, describing the fetched content.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] payload                A reference to the buffer, describing the URI to be fetched.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_check_fetch_integrated(suit_component_t dst_handle, struct zcbor_string *payload,
+				     struct zcbor_string *manifest_component_id,
+				     struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given copy operation can be performed.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] src_handle  A reference to the source component.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] src_handle             A reference to the source component.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_copy(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_check_copy(suit_component_t dst_handle, suit_component_t src_handle,
+			 struct zcbor_string *manifest_component_id,
+			 struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given swap operation can be performed.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] src_handle  A reference to the source component.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] src_handle             A reference to the source component.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_swap(suit_component_t dst_handle, suit_component_t src_handle, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_check_swap(suit_component_t dst_handle, suit_component_t src_handle,
+			 struct zcbor_string *manifest_component_id,
+			 struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given invoke operation can be performed.
  *
- * @param[in] dst_handle  A reference to the destination component.
- * @param[in] content     A reference to the buffer, describing the content.
+ * @param[in] dst_handle             A reference to the destination component.
+ * @param[in] content                A reference to the buffer, describing the content.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest
+ *                                   in the system.
+ * @param[in] enc_info               A reference to the structure, containing encryption info.
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_plat_check_write(suit_component_t dst_handle, struct zcbor_string *content, struct zcbor_string *manifest_component_id, struct suit_encryption_info *enc_info);
+int suit_plat_check_write(suit_component_t dst_handle, struct zcbor_string *content,
+			  struct zcbor_string *manifest_component_id,
+			  struct suit_encryption_info *enc_info);
 
 /** @brief Check that the given invoke operation can be performed.
  *

--- a/include/suit_platform.h
+++ b/include/suit_platform.h
@@ -255,12 +255,13 @@ int suit_plat_retrieve_manifest(suit_component_t component_handle, const uint8_t
 
 /** @brief Set the current image size value, stored inside the platform component metadata.
  *
- * @param[in]  handle  A reference to the component, describing the SUIT envelope.
- * @param[in]  size    The component size, set by the manifest command.
+ * @param[in] handle                 A reference to the component, describing the SUIT envelope.
+ * @param[in] size                   The component size, set by the manifest command.
+ * @param[in] manifest_component_id  The manifest component ID, identifying the type of manifest in the system.
  *
  * @returns SUIT_SUCCESS if the size was set, error code otherwise.
  */
-int suit_plat_override_image_size(suit_component_t handle, size_t size);
+int suit_plat_override_image_size(suit_component_t handle, size_t size, struct zcbor_string *manifest_component_id);
 
 /** @brief Authorize execution of the given sequence of the dependency manifest.
  *

--- a/include/suit_processor.h
+++ b/include/suit_processor.h
@@ -42,7 +42,7 @@ typedef int (*seq_exec_processor_t)(struct suit_processor_state *state, suit_com
 
 enum suit_bool {
 	suit_bool_false = 0x2a17644c, ///! 10 1010 0001 0111 0110 0100 0100 1100
-	suit_bool_true = 0x713cf9c6, ///! 111 0001 0011 1100 1111 1001 1100 0110
+	suit_bool_true = 0x713cf9c6,  ///! 111 0001 0011 1100 1111 1001 1100 0110
 };
 
 struct suit_semver {
@@ -194,18 +194,26 @@ struct suit_manifest_state {
  *       directive to select the correct command block.
  */
 struct suit_seq_exec_state {
-	struct zcbor_string cmd_seq_str; ///! Structure describing the currently executed command sequence.
-	size_t n_commands; ///! The number of commands expected inside the currently executed command sequence.
-	size_t current_command; ///! The index of currently executed command within the executed command sequence.
-	int cmd_exec_state; ///! Optional current command execution state.
+	struct zcbor_string
+		cmd_seq_str;	///! Structure describing the currently executed command sequence.
+	size_t n_commands;	///! The number of commands expected inside the currently executed
+				/// command sequence.
+	size_t current_command; ///! The index of currently executed command within the executed
+				/// command sequence.
+	int cmd_exec_state;	///! Optional current command execution state.
 	enum suit_bool soft_failure; ///! suit-parameter-soft-failure
-	int retval; ///! Value returned by the nested command sequence execution.
-	seq_exec_processor_t cmd_processor; ///! The command processor to use to process the sequence.
+	int retval;		     ///! Value returned by the nested command sequence execution.
+	seq_exec_processor_t
+		cmd_processor; ///! The command processor to use to process the sequence.
 	struct suit_manifest_state *manifest; ///! The reference to the current manifest structure.
-	const uint8_t *exec_ptr; ///! The pointer within the currently executed command sequence, pointing to the current command in the sequence.
-	size_t current_component_idx; ///! In case of nested command execution - the currently selected component from the component list.
+	const uint8_t *exec_ptr; ///! The pointer within the currently executed command sequence,
+				 /// pointing to the current command in the sequence.
+	size_t current_component_idx; ///! In case of nested command execution - the currently
+				      /// selected component from the component list.
 	bool current_components[SUIT_MAX_NUM_COMPONENTS];
-	bool current_components_backup[SUIT_MAX_NUM_COMPONENTS]; //! List of components, selected before the execution of command sequences.
+	bool current_components_backup[SUIT_MAX_NUM_COMPONENTS]; //! List of components, selected
+								 //! before the execution of command
+								 //! sequences.
 };
 
 struct suit_processor_state {
@@ -224,7 +232,6 @@ struct suit_processor_state {
 	size_t seq_stack_height;
 	struct suit_seq_exec_state seq_stack[SUIT_MAX_SEQ_DEPTH];
 };
-
 
 /** @brief Populate the manifest stack by loading a new envelope.
  *
@@ -246,7 +253,8 @@ struct suit_processor_state {
  *
  * @returns SUIT_SUCCESS if the operation succeeds, error code otherwise.
  */
-int suit_processor_load_envelope(struct suit_processor_state *state, const uint8_t *envelope_str, size_t envelope_len);
+int suit_processor_load_envelope(struct suit_processor_state *state, const uint8_t *envelope_str,
+				 size_t envelope_len);
 
 #ifdef CONFIG_UNITY
 /** @brief Override the internal state variable with a pointer to the external memory.

--- a/include/suit_report.h
+++ b/include/suit_report.h
@@ -14,16 +14,15 @@
 extern "C" {
 #endif /* __cplusplus */
 
-/** Construct a report for the given command.
+/** @brief Construct a report for the given command.
  *
- *  @param[in]  command  The command that was executed.
- *  @param[in]  result  The result of the command.
+ *  @param[in]  command     The command that was executed.
+ *  @param[in]  result      The result of the command.
  *  @param[in]  parameters  The current parameters.
- *  @param[out] report  The constructed report.
+ *  @param[out] report      The constructed report.
  */
-int suit_construct_report(unsigned int command, int result,
-		struct suit_manifest_params *parameters,
-		struct suit_report *report);
+int suit_construct_report(unsigned int command, int result, struct suit_manifest_params *parameters,
+			  struct suit_report *report);
 
 #ifdef __cplusplus
 }

--- a/include/suit_schedule_seq.h
+++ b/include/suit_schedule_seq.h
@@ -19,9 +19,12 @@ extern "C" {
  * @param[in]  manifest  Manifest structure that holds the command sequence.
  * @param[in]  seq_name  Name of the command sequence to execute.
  *
- * @returns SUIT_ERR_AGAIN if the sequence execution was successfully scheduled, error code otherwise.
+ * @returns SUIT_ERR_AGAIN if the sequence execution was successfully scheduled, error code
+ *                         otherwise.
  */
-int suit_schedule_execution(struct suit_processor_state *state, struct suit_manifest_state *manifest, enum suit_command_sequence seq_name);
+int suit_schedule_execution(struct suit_processor_state *state,
+			    struct suit_manifest_state *manifest,
+			    enum suit_command_sequence seq_name);
 
 /** Schedule validation of all commands in the sequence from the current manifest.
  *
@@ -32,9 +35,12 @@ int suit_schedule_execution(struct suit_processor_state *state, struct suit_mani
  * @param[in]  manifest  Manifest structure that holds the command sequence.
  * @param[in]  seq_name  Name of the command sequence to validate.
  *
- * @returns SUIT_ERR_AGAIN if the sequence validation was successfully scheduled, error code otherwise.
+ * @returns SUIT_ERR_AGAIN if the sequence validation was successfully scheduled, error code
+ *                         otherwise.
  */
-int suit_schedule_validation(struct suit_processor_state *state, struct suit_manifest_state *manifest, enum suit_command_sequence seq_name);
+int suit_schedule_validation(struct suit_processor_state *state,
+			     struct suit_manifest_state *manifest,
+			     enum suit_command_sequence seq_name);
 
 /** Process all operations scheduled.
  *

--- a/include/suit_seq_exec.h
+++ b/include/suit_seq_exec.h
@@ -20,20 +20,27 @@ extern "C" {
  *       The command execution is done from the suit_seq_exec_step(..) calls.
  *
  * @param[in]  state             The SUIT processor state to modify.
- * @param[in]  manifest          Reference to the manifest structure, for which the sequence will be executed.
+ * @param[in]  manifest          Reference to the manifest structure, for which the sequence will be
+ *                               executed.
  * @param[in]  command_sequence  Command sequence to be scheduled.
- * @param[in]  soft_failure      The initial value of the suit-parameter-soft-failure for the sequence.
+ * @param[in]  soft_failure      The initial value of the suit-parameter-soft-failure for the
+ *                               sequence.
  * @param[in]  cmd_processor     Processor to execute commands in the sequence.
  *
  * @retval SUIT_ERR_AGAIN     If the command has been successfully scheduled.
- * @retval SUIT_ERR_OVERFLOW  If the command execution stack was too small to schedule the new sequence.
+ * @retval SUIT_ERR_OVERFLOW  If the command execution stack was too small to schedule the new
+ *                            sequence.
  */
-int suit_seq_exec_schedule(struct suit_processor_state *state, struct suit_manifest_state *manifest, struct zcbor_string *command_sequence, enum suit_bool soft_failure, seq_exec_processor_t cmd_processor);
+int suit_seq_exec_schedule(struct suit_processor_state *state, struct suit_manifest_state *manifest,
+			   struct zcbor_string *command_sequence, enum suit_bool soft_failure,
+			   seq_exec_processor_t cmd_processor);
 
 /** @brief Execute the scheduled command sequence.
  *
- * @note This function only executes the sequence as long as it does not require execution of nested sequence.
- *       In such case, the API returns SUIT_ERR_AGAIN and should be called again to continue the execution.
+ * @note This function only executes the sequence as long as it does not require execution of nested
+ *       sequence.
+ *       In such case, the API returns SUIT_ERR_AGAIN and should be called again to continue the
+ *       execution.
  *
  * @param[in]  state  The SUIT processor state to modify.
  *
@@ -46,21 +53,24 @@ int suit_seq_exec_step(struct suit_processor_state *state);
 /** @brief Get the current command sequence execution state.
  *
  * @param[in]   state           The SUIT processor state to be used.
- * @param[out]  seq_exec_state  Pointer to the reference that will be set to the current command sequence.
+ * @param[out]  seq_exec_state  Pointer to the reference that will be set to the current command
+ *                              sequence.
  *
  * @retval  SUIT_SUCCESS    If the state was successfully passed through the pointer.
- * @retval  SUIT_ERR_CRASH  If the pointer is invalid or there was no state to be returned (empty stack).
+ * @retval  SUIT_ERR_CRASH  If the pointer is invalid or there was no state to be returned (empty
+ *                          stack).
  */
-int suit_seq_exec_state_get(struct suit_processor_state *state, struct suit_seq_exec_state **seq_exec_state);
+int suit_seq_exec_state_get(struct suit_processor_state *state,
+			    struct suit_seq_exec_state **seq_exec_state);
 
 /** @brief Pop a single element from the execution stack and pass error code to the caller.
  *
  * @param[in]  state   The SUIT processor state to be modified.
  * @param[in]  retval  Error code to be passed to the caller.
  *
- * @returns If the execution status was passed to the caller and the execution stack is not finished,
- *          the SUIT_ERR_AGAIN error code is returnded.
- *          If the execution was finished, the result of all sequences is returned.
+ * @returns If the execution status was passed to the caller and the execution stack is not
+ *          finished, the SUIT_ERR_AGAIN error code is returnded. If the execution was finished,
+ *          the result of all sequences is returned.
  */
 int suit_seq_exec_finalize(struct suit_processor_state *state, int retval);
 
@@ -69,28 +79,34 @@ int suit_seq_exec_finalize(struct suit_processor_state *state, int retval);
  * @note This API is used to implement the loop, which executes nested command sequence on
  *       a list of components in a on-by-one order.
  * @note If the API is called for the first time on an execution context, it will create a backup
- *       of the list of currently selected components and select the first component index afterwards.
+ *       of the list of currently selected components and select the first component index
+ *       afterwards.
  *
  * @param[in]   seq_exec_state  The SUIT processor execution state to be used.
- * @param[out]  component_idx   Pointer to the variable, that will be set with the current component index value.
+ * @param[out]  component_idx   Pointer to the variable, that will be set with the current component
+ *                              index value.
  *
  * @returns SUIT_SUCCESS if the current component was successfully returned, error code otherwise.
  */
-int suit_seq_exec_component_idx_get(struct suit_seq_exec_state *seq_exec_state, size_t *component_idx);
+int suit_seq_exec_component_idx_get(struct suit_seq_exec_state *seq_exec_state,
+				    size_t *component_idx);
 
 /** @brief Switch to the next component index, on which the sequence will be executed.
  *
  * @note This API is used to implement the loop, which executes nested command sequence on
  *       a list of components in a on-by-one order.
- * @note If the list of selected components is exhausted, the component_idx will be set to SUIT_MAX_NUM_COMPONENTS
- *       and this API will automatically restore the list of selected components from the backup.
+ * @note If the list of selected components is exhausted, the component_idx will be set to
+ *       SUIT_MAX_NUM_COMPONENTS and this API will automatically restore the list of selected
+ *       components from the backup.
  *
  * @param[in]   seq_exec_state  The SUIT processor execution state to be used.
- * @param[out]  component_idx   Pointer to the variable, that will be set with the current component index value.
+ * @param[out]  component_idx   Pointer to the variable, that will be set with the current component
+ *                              index value.
  *
  * @returns SUIT_SUCCESS if the current component was successfully returned, error code otherwise.
  */
-int suit_seq_exec_component_idx_next(struct suit_seq_exec_state *seq_exec_state, size_t *component_idx);
+int suit_seq_exec_component_idx_next(struct suit_seq_exec_state *seq_exec_state,
+				     size_t *component_idx);
 
 /** @brief Add a component specified by an index to the list of selected components.
  *
@@ -121,21 +137,25 @@ int suit_exec_deselect_all_components(struct suit_seq_exec_state *seq_exec_state
  *
  * @param[in]   seq_exec_state  The SUIT processor execution state to be used.
  * @param[in]   component_idx   The component index of the current manifest.
- * @param[out]  handle          Pointer to the variable, that will be set with the resolved component handle.
+ * @param[out]  handle          Pointer to the variable, that will be set with the resolved
+ *                              component handle.
  *
  * @returns SUIT_SUCCESS if the component handle was found and returned, error code otherwise.
  */
-int suit_exec_component_handle_from_idx(struct suit_seq_exec_state *seq_exec_state, size_t component_idx, suit_component_t *handle);
+int suit_exec_component_handle_from_idx(struct suit_seq_exec_state *seq_exec_state,
+					size_t component_idx, suit_component_t *handle);
 
 /** @brief Look for URI in the list of integrated payload of the current manifest.
  *
  * @param[in]   seq_exec_state  The SUIT processor execution state to be used.
  * @param[in]   uri             URI to look for.
- * @param[out]  payload         Pointer to the variable, that will be set with the reference and size of the integrated payload.
+ * @param[out]  payload         Pointer to the variable, that will be set with the reference and
+ *                              size of the integrated payload.
  *
  * @returns SUIT_SUCCESS if the integrated payload was found and returned, error code otherwise.
  */
-int suit_exec_find_integrated_payload(struct suit_seq_exec_state *seq_exec_state, struct zcbor_string *uri, struct zcbor_string *payload);
+int suit_exec_find_integrated_payload(struct suit_seq_exec_state *seq_exec_state,
+				      struct zcbor_string *uri, struct zcbor_string *payload);
 
 #ifdef __cplusplus
 }

--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -15,56 +15,99 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define SUIT_MAX_NUM_SIGNERS 2  ///! The maximum number of signers.
-#define SUIT_MAX_NUM_COMPONENT_ID_PARTS 5  ///! The maximum number of bytestrings in a component ID.
-#define SUIT_MAX_NUM_COMPONENTS 12  ///! The maximum number of components referenced in the manifest.
-#define SUIT_MAX_NUM_COMPONENT_PARAMS (SUIT_MAX_NUM_COMPONENTS * SUIT_MANIFEST_STACK_MAX_ENTRIES) ///! The maximum number of active components during processing dependency manifests.
-#define SUIT_MAX_NUM_INTEGRATED_PAYLOADS 6  ///! The maximum number of integrated payloads in a single manifest.
-#define SUIT_MAX_COMMAND_ARGS 3  ///! The maximum number of arguments consumed by a single command.
-#define SUIT_SUIT_SIG_STRUCTURE1_MAX_LENGTH 95  ///! The maximum length of the Sig_structure1 structure. Current value allows to store up to 512-bit long digests with 32-bit key id.
-#define SUIT_MAX_SEQ_DEPTH 5  ///! The maximum number of command sequences that may be encapsulated.
-#define SUIT_SEQ_EXEC_DEFAULT_STATE 0  ///! The default value of the cmd_exec_state.
-#define SUIT_MAX_MANIFEST_DEPTH 3 ///! The maximum nesting level of hierarchical manifests.
-#define SUIT_MANIFEST_STACK_MAX_ENTRIES (SUIT_MAX_MANIFEST_DEPTH + 1) ///! Maximum amount of manifests to be stored on stack. One entry for each manifest level + one for additional processing.
+/** The maximum number of signers. */
+#define SUIT_MAX_NUM_SIGNERS		    2
+/** The maximum number of bytestrings in a component ID. */
+#define SUIT_MAX_NUM_COMPONENT_ID_PARTS	    5
+/** The maximum number of components referenced in the manifest. */
+#define SUIT_MAX_NUM_COMPONENTS		    12
+/** The maximum number of active components during processing dependency manifests. */
+#define SUIT_MAX_NUM_COMPONENT_PARAMS	    (SUIT_MAX_NUM_COMPONENTS * SUIT_MANIFEST_STACK_MAX_ENTRIES)
+/** The maximum number of integrated payloads in a single manifest. */
+#define SUIT_MAX_NUM_INTEGRATED_PAYLOADS    6
+/** The maximum number of arguments consumed by a single command. */
+#define SUIT_MAX_COMMAND_ARGS		    3
+/** The maximum length of the Sig_structure1 structure.
+ *  Current value allows to store up to 512-bit long digests with 32-bit key id.
+ */
+#define SUIT_SUIT_SIG_STRUCTURE1_MAX_LENGTH 95
+/** The maximum number of command sequences that may be encapsulated. */
+#define SUIT_MAX_SEQ_DEPTH		    5
+/** The default value of the cmd_exec_state. */
+#define SUIT_SEQ_EXEC_DEFAULT_STATE	    0
+/** The maximum nesting level of hierarchical manifests. */
+#define SUIT_MAX_MANIFEST_DEPTH		    3
+/** Maximum amount of manifests to be stored on stack.
+ *  One entry for each manifest level + one for additional processing.
+ */
+#define SUIT_MANIFEST_STACK_MAX_ENTRIES	    (SUIT_MAX_MANIFEST_DEPTH + 1)
 
 /** Errors from the suit API
  *
- * See also https://www.ietf.org/archive/id/draft-ietf-suit-manifest-25.html#name-manifest-processor-setup
+ * See also
+ * https://www.ietf.org/archive/id/draft-ietf-suit-manifest-25.html#name-manifest-processor-setup
  * and https://www.ietf.org/archive/id/draft-ietf-suit-report-08.html#section-4-14
  * for more report reasons and error conditions.
  */
-#define SUIT_SUCCESS                      0
-#define SUIT_FAIL_CONDITION               1 // Test failed (e.g. Vendor ID/Class ID).
-#define SUIT_ERR_TAMP                     3 // Tampering detected in processing.
-#define SUIT_ERR_ORDER                    4 // API called in an invalid order.
-#define SUIT_ERR_WAIT                     5 // Platform operation should be retried later.
-#define SUIT_ERR_DECODING                 6 // Failed to decode the payload.
-#define SUIT_ERR_AUTHENTICATION           7 // Envelope authentication failed.
-#define SUIT_ERR_MANIFEST_VERIFICATION    8 // Manifest (cryptographic) verification failed.
-#define SUIT_ERR_MANIFEST_VALIDATION      9 // Manifest validation failed (rule broken).
-#define SUIT_ERR_PAYLOAD_VERIFICATION     10 // Payload verification failed.
-#define SUIT_ERR_UNAVAILABLE_PAYLOAD      11 // Payload not available.
-#define SUIT_ERR_UNAVAILABLE_COMMAND_SEQ  12 // Command sequence not available. (FATAL?)
-#define SUIT_ERR_UNAVAILABLE_PARAMETER    13 // Required parameter not supplied.
-#define SUIT_ERR_UNSUPPORTED_COMMAND      14 // Unsupported command encountered.
-#define SUIT_ERR_UNSUPPORTED_PARAMETER    15 // Unsupported parameter encountered.
-#define SUIT_ERR_UNSUPPORTED_COMPONENT_ID 16 // Unsupported Component Identifier encountered.
-#define SUIT_ERR_MISSING_COMPONENT        17 // Missing required component from a Component Set.
-#define SUIT_ERR_CRASH                    18 // Application crashed when executed.
-#define SUIT_ERR_TIMEOUT                  19 // Watchdog timeout occurred.
-#define SUIT_ERR_UNSUPPORTED_COSE         20 // Unsupported type of COSE structure encountered.
-#define SUIT_ERR_UNSUPPORTED_ALG          21 // Unsupported COSE algorithm encountered.
-#define SUIT_ERR_UNAUTHORIZED_COMPONENT   22 // Unauthorized component ID.
-#define SUIT_ERR_UNAUTHORIZED_COMMAND_SEQ 23 // Severed command sequence not authorized.
-#define SUIT_ERR_AGAIN                    100 // The execution has not yet finished. Call the API again.
-#define SUIT_ERR_OVERFLOW                 101 // The execution context is too small to handle the command sequence.
-#define SUIT_FAIL_SOFT_CONDITION          102 // Test failed (e.g. Vendor ID/Class ID) and soft-failure parameter was set to true.
+/** Execution successful. */
+#define SUIT_SUCCESS			  0
+/** Test failed (e.g. Vendor ID/Class ID). */
+#define SUIT_FAIL_CONDITION		  1
+/** Tampering detected in processing. */
+#define SUIT_ERR_TAMP			  3
+/** API called in an invalid order. */
+#define SUIT_ERR_ORDER			  4
+/** Platform operation should be retried later. */
+#define SUIT_ERR_WAIT			  5
+/** Failed to decode the payload. */
+#define SUIT_ERR_DECODING		  6
+/** Envelope authentication failed. */
+#define SUIT_ERR_AUTHENTICATION		  7
+/**  Manifest (cryptographic) verification failed. */
+#define SUIT_ERR_MANIFEST_VERIFICATION	  8
+/**  Manifest validation failed (rule broken). */
+#define SUIT_ERR_MANIFEST_VALIDATION	  9
+/** Payload verification failed. */
+#define SUIT_ERR_PAYLOAD_VERIFICATION	  10
+/** Payload not available. */
+#define SUIT_ERR_UNAVAILABLE_PAYLOAD	  11
+/** Command sequence not available. (FATAL?) */
+#define SUIT_ERR_UNAVAILABLE_COMMAND_SEQ  12
+/** Required parameter not supplied. */
+#define SUIT_ERR_UNAVAILABLE_PARAMETER	  13
+/** Unsupported command encountered. */
+#define SUIT_ERR_UNSUPPORTED_COMMAND	  14
+/** Unsupported parameter encountered. */
+#define SUIT_ERR_UNSUPPORTED_PARAMETER	  15
+/** Unsupported Component Identifier encountered. */
+#define SUIT_ERR_UNSUPPORTED_COMPONENT_ID 16
+/** Missing required component from a Component Set. */
+#define SUIT_ERR_MISSING_COMPONENT	  17
+/** Application crashed when executed. */
+#define SUIT_ERR_CRASH			  18
+/** Watchdog timeout occurred. */
+#define SUIT_ERR_TIMEOUT		  19
+/** Unsupported type of COSE structure encountered. */
+#define SUIT_ERR_UNSUPPORTED_COSE	  20
+/** Unsupported COSE algorithm encountered. */
+#define SUIT_ERR_UNSUPPORTED_ALG	  21
+/** Unauthorized component ID. */
+#define SUIT_ERR_UNAUTHORIZED_COMPONENT	  22
+/** Severed command sequence not authorized. */
+#define SUIT_ERR_UNAUTHORIZED_COMMAND_SEQ 23
+/** The execution has not yet finished. Call the API again. */
+#define SUIT_ERR_AGAIN			  100
+/** The execution context is too small to handle the command sequence. */
+#define SUIT_ERR_OVERFLOW		  101
+/** Test failed (e.g. Vendor ID/Class ID) and soft-failure parameter was set to true. */
+#define SUIT_FAIL_SOFT_CONDITION	  102
 
-
-#define SUIT_ZCBOR_ERR_OFFSET 128
+/** Offset for all ZCBOR parsing error codes. */
+#define SUIT_ZCBOR_ERR_OFFSET		 128
 #define ZCBOR_ERR_TO_SUIT_ERR(zcbor_err) ((zcbor_err) + SUIT_ZCBOR_ERR_OFFSET)
 
-typedef intptr_t suit_component_t; ///! Handle to more easily refer to a component.
+/** Handle to more easily refer to a component. */
+typedef intptr_t suit_component_t;
 
 enum suit_command_sequence {
 	SUIT_SEQ_INVALID,
@@ -93,8 +136,14 @@ enum suit_cose_alg {
 };
 
 struct suit_arg {
-	union{struct zcbor_string *bstr; unsigned int num; } arg;
-	enum{bstr, num} arg_type;
+	union {
+		struct zcbor_string *bstr;
+		unsigned int num;
+	} arg;
+	enum {
+		bstr,
+		num
+	} arg_type;
 };
 
 struct suit_report {
@@ -142,9 +191,11 @@ struct suit_encryption_info {
 	union suit_key_encryption_data kw_key;
 };
 
-static inline bool suit_compare_zcbor_strings(const struct zcbor_string *str1, const struct zcbor_string *str2)
+static inline bool suit_compare_zcbor_strings(const struct zcbor_string *str1,
+					      const struct zcbor_string *str2)
 {
-	return (str1 != NULL) && (str2 != NULL) && (str1->len == str2->len) && (memcmp(str1->value, str2->value, str1->len) == 0);
+	return (str1 != NULL) && (str2 != NULL) && (str1->len == str2->len) &&
+	       (memcmp(str1->value, str2->value, str1->len) == 0);
 }
 
 #ifdef __cplusplus

--- a/tests/unit/fetch_integrated_manifests/include/suit_platform_mock_ext.h
+++ b/tests/unit/fetch_integrated_manifests/include/suit_platform_mock_ext.h
@@ -284,4 +284,14 @@ int __write_callback(suit_component_t dst_handle, struct zcbor_string *content, 
 }
 int __dependency_seq_authorize_callback(struct zcbor_string *parent_component_id, struct zcbor_string *child_component_id, enum suit_command_sequence seq_name, int cmock_num_calls);
 
+#define __cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(handle, size, manifest_component_id, cmock_retval) { \
+	extern complex_arg_q_t __override_image_size_callback_queue; \
+	push_complex_arg(manifest_component_id, assert_zcbor_string, __override_image_size_callback_queue); \
+	push_retval_arg(cmock_retval, __override_image_size_callback_queue); \
+	__cmock_suit_plat_override_image_size_AddCallback(__override_image_size_callback); \
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(handle, size, manifest_component_id, cmock_retval); \
+	__cmock_suit_plat_override_image_size_IgnoreArg_manifest_component_id(); \
+}
+int __override_image_size_callback(suit_component_t handle, size_t size, struct zcbor_string *manifest_component_id, int cmock_num_calls);
+
 #endif /* _SUIT_PLATFORM_MOCK_EXT_H */

--- a/tests/unit/fetch_integrated_manifests/src/main.c
+++ b/tests/unit/fetch_integrated_manifests/src/main.c
@@ -137,8 +137,8 @@ void test_suit_process_seq_dependency_resolution(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_DEP_RESOLUTION, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -155,8 +155,8 @@ void test_suit_process_seq_dependency_resolution(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_DEP_RESOLUTION, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_DEP_RESOLUTION, &exp_radio_manifest_id, exp_radio_envelope_payload.value, exp_radio_envelope_payload.len, SUIT_SUCCESS);
@@ -173,8 +173,8 @@ void test_suit_process_seq_dependency_resolution(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_DEP_RESOLUTION, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_DEP_RESOLUTION, &exp_app_manifest_id, exp_app_envelope_payload.value, exp_app_envelope_payload.len, SUIT_SUCCESS);
@@ -198,8 +198,8 @@ void test_suit_process_seq_payload_fetch(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_PAYLOAD_FETCH, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -216,8 +216,8 @@ void test_suit_process_seq_payload_fetch(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_PAYLOAD_FETCH, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_PAYLOAD_FETCH, &exp_radio_manifest_id, exp_radio_envelope_payload.value, exp_radio_envelope_payload.len, SUIT_SUCCESS);
@@ -234,8 +234,8 @@ void test_suit_process_seq_payload_fetch(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_PAYLOAD_FETCH, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_PAYLOAD_FETCH, &exp_app_manifest_id, exp_app_envelope_payload.value, exp_app_envelope_payload.len, SUIT_SUCCESS);
@@ -261,8 +261,8 @@ void test_suit_process_seq_candidate_verification(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_CAND_VERIFICATION, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -279,8 +279,8 @@ void test_suit_process_seq_candidate_verification(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_CAND_VERIFICATION, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_CAND_VERIFICATION, &exp_radio_manifest_id, exp_radio_envelope_payload.value, exp_radio_envelope_payload.len, SUIT_SUCCESS);
@@ -297,8 +297,8 @@ void test_suit_process_seq_candidate_verification(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_CAND_VERIFICATION, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_CAND_VERIFICATION, &exp_app_manifest_id, exp_app_envelope_payload.value, exp_app_envelope_payload.len, SUIT_SUCCESS);
@@ -322,8 +322,8 @@ void test_suit_process_seq_install(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_INSTALL, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -340,8 +340,8 @@ void test_suit_process_seq_install(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_INSTALL, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_INSTALL sequence from the radio manifest */
@@ -363,8 +363,8 @@ void test_suit_process_seq_install(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_INSTALL, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_INSTALL sequence from the application manifest */
@@ -393,8 +393,8 @@ void test_suit_process_seq_validate(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_VALIDATE, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -415,8 +415,8 @@ void test_suit_process_seq_validate(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_VALIDATE, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_VALIDATE sequence from the radio manifest */
@@ -429,8 +429,8 @@ void test_suit_process_seq_validate(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_VALIDATE, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_VALIDATE sequence from the application manifest */
@@ -456,8 +456,8 @@ void test_suit_process_seq_load(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_LOAD, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -476,8 +476,8 @@ void test_suit_process_seq_load(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_LOAD, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_LOAD, &exp_radio_manifest_id, exp_radio_envelope_payload.value, exp_radio_envelope_payload.len, SUIT_SUCCESS);
@@ -488,8 +488,8 @@ void test_suit_process_seq_load(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_LOAD, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_sequence_completed_ExpectComplexArgsAndReturn(SUIT_SEQ_LOAD, &exp_app_manifest_id, exp_app_envelope_payload.value, exp_app_envelope_payload.len, SUIT_SUCCESS);
@@ -513,8 +513,8 @@ void test_suit_process_seq_invoke(void)
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_INVOKE, &exp_root_manifest_id, 1, SUIT_SUCCESS);
 
 	/* SUIT_COMMMON sequence from the root manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_component_handle, exp_radio_envelope_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_component_handle, exp_app_envelope_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_component_handle, exp_radio_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_component_handle, exp_app_envelope_payload.len, &exp_root_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
@@ -533,8 +533,8 @@ void test_suit_process_seq_invoke(void)
 	radio_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_INVOKE, &exp_radio_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the radio manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(radio_fw_memptr_component_handle, exp_radio_fw_payload.len, &exp_radio_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(radio_fw_component_handle, &exp_radio_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_INVOKE sequence from the radio manifest */
@@ -547,8 +547,8 @@ void test_suit_process_seq_invoke(void)
 	app_assert_component_creation();
 	__cmock_suit_plat_authorize_sequence_num_ExpectComplexArgsAndReturn(SUIT_SEQ_INVOKE, &exp_app_manifest_id, 1, SUIT_SUCCESS);
 	/* SUIT_COMMON sequence from the application manifest */
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectComplexArgsAndReturn(app_fw_memptr_component_handle, exp_app_fw_payload.len, &exp_app_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(app_fw_component_handle, &exp_app_cid_uuid, SUIT_SUCCESS);
 	/* SUIT_INVOKE sequence from the application manifest */

--- a/tests/unit/fetch_integrated_manifests/src/suit_platform_mock_ext.c
+++ b/tests/unit/fetch_integrated_manifests/src/suit_platform_mock_ext.c
@@ -177,3 +177,10 @@ int __dependency_seq_authorize_callback(struct zcbor_string *parent_component_id
 	(void)assert_complex_arg(&__dependency_seq_authorize_callback_queue, child_component_id);
 	return assert_complex_arg(&__dependency_seq_authorize_callback_queue, NULL);
 }
+
+COMPLEX_ARG_Q_DEFINE(__override_image_size_callback_queue);
+int __override_image_size_callback(suit_component_t handle, size_t size, struct zcbor_string *manifest_component_id, int cmock_num_calls)
+{
+	(void)assert_complex_arg(&__override_image_size_callback_queue, manifest_component_id);
+	return assert_complex_arg(&__override_image_size_callback_queue, NULL);
+}

--- a/tests/unit/fetch_integrated_payload/src/main.c
+++ b/tests/unit/fetch_integrated_payload/src/main.c
@@ -286,7 +286,7 @@ void test_suit_process_seq_install(void)
 
 	__cmock_suit_plat_authorize_sequence_num_ExpectAndReturn(SUIT_SEQ_INSTALL, &exp_manifest_id, 1, SUIT_SUCCESS);
 	__cmock_suit_plat_authorize_sequence_num_AddCallback(authorize_sequence_num_callback);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, &exp_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_fetch_integrated_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_image_payload, &exp_manifest_id, NULL, SUIT_SUCCESS);
@@ -310,7 +310,7 @@ void test_suit_process_seq_validate(void)
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 
 	__cmock_suit_plat_authorize_sequence_num_ExpectAndReturn(SUIT_SEQ_VALIDATE, &exp_manifest_id, 1, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, &exp_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_image_match_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, suit_cose_sha256, &exp_image_digest, SUIT_SUCCESS);
@@ -349,7 +349,7 @@ void test_suit_process_seq_invoke(void)
 #endif /* SUIT_PLATFORM_DRY_RUN_SUPPORT */
 
 	__cmock_suit_plat_authorize_sequence_num_ExpectAndReturn(SUIT_SEQ_INVOKE, &exp_manifest_id, 1, SUIT_SUCCESS);
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, 256, &exp_manifest_id, SUIT_SUCCESS);
 	__cmock_suit_plat_check_vid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_vid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_check_cid_ExpectComplexArgsAndReturn(ASSIGNED_COMPONENT_HANDLE, &exp_cid_uuid, SUIT_SUCCESS);
 	__cmock_suit_plat_invoke_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, NULL, SUIT_SUCCESS);

--- a/tests/unit/seq_execution/src/test_directive_override_parameters.c
+++ b/tests/unit/seq_execution/src/test_directive_override_parameters.c
@@ -13,6 +13,11 @@
 
 extern struct suit_processor_state state;
 
+static struct zcbor_string exp_manifest_id = {
+	.value = NULL,
+	.len = 0,
+};
+
 static int execute_command_sequence(struct suit_processor_state *state, struct zcbor_string *cmd_seq_str)
 {
 	enum suit_command_sequence seq = SUIT_SEQ_PAYLOAD_FETCH;
@@ -112,7 +117,7 @@ void test_seq_execution_override_parameter_single_component_6params(void)
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_components(&state, 1);
 
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_image_size, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_image_size, &exp_manifest_id, SUIT_SUCCESS);
 
 	int retval = execute_command_sequence(&state, &seq);
 

--- a/tests/unit/seq_execution/src/test_directive_set_parameters.c
+++ b/tests/unit/seq_execution/src/test_directive_set_parameters.c
@@ -13,6 +13,11 @@
 
 extern struct suit_processor_state state;
 
+static struct zcbor_string exp_manifest_id = {
+	.value = NULL,
+	.len = 0,
+};
+
 static int execute_command_sequence(struct suit_processor_state *state, struct zcbor_string *cmd_seq_str)
 {
 	enum suit_command_sequence seq = SUIT_SEQ_PAYLOAD_FETCH;
@@ -113,7 +118,7 @@ void test_seq_execution_set_parameter_single_component_6params(void)
 	bootstrap_envelope_empty(&state);
 	bootstrap_envelope_components(&state, 1);
 
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_image_size, SUIT_SUCCESS);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE, exp_image_size, &exp_manifest_id, SUIT_SUCCESS);
 
 	int retval = execute_command_sequence(&state, &seq);
 
@@ -424,7 +429,7 @@ void test_seq_execution_set_parameter_multiple_components_image_size_failed(void
 	state.components[2].image_size_set = true;
 	state.components[3].image_size_set = false;
 
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE + 1, exp_image_size, SUIT_ERR_CRASH);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE + 1, exp_image_size, &exp_manifest_id, SUIT_ERR_CRASH);
 
 	int retval = execute_command_sequence(&state, &seq);
 
@@ -532,7 +537,7 @@ void test_seq_execution_set_parameter_lazy_platform_image_size_set(void)
 	state.components[2].image_size_set = true;
 	state.components[3].image_size_set = false;
 
-	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE + 1, exp_image_size, SUIT_ERR_AGAIN);
+	__cmock_suit_plat_override_image_size_ExpectAndReturn(ASSIGNED_COMPONENT_HANDLE + 1, exp_image_size, &exp_manifest_id, SUIT_ERR_AGAIN);
 
 	int retval = execute_command_sequence(&state, &seq);
 


### PR DESCRIPTION
This piece of information is required by the IPUC declare API.