### PR TITLE
cddl: Set the maximum number of active components

### DIFF
--- a/cddl/manifest.cddl
+++ b/cddl/manifest.cddl
@@ -8,7 +8,7 @@
 ; Removed unused COSE types
 ; Removed COSE authentication block from manifest CDDL - defined and parsed by Cose CDDL
 ; Force making suit-text severable.
-; Limited the number of possible component identifiers to 12
+; Limited the number of possible component identifiers to 16
 ; Limited the length of component identifiers to 5 strings
 ; Remove all hash algs except sha256 and sha512
 ; Remove most of text comprehension since the firmware isn't supposed to understand the text.
@@ -20,6 +20,7 @@
 ; Set the maximum number of try-each cases 5
 ; Set the maximum number of language tags to 2
 ; Allow to use both 17 and 20 as suit-install sequence key
+; Specify the maximum length of active components indexes to 16
 ;
 
 SUIT_Envelope_Tagged = #6.107(SUIT_Envelope)
@@ -103,7 +104,7 @@ SUIT_Common = {
   0*1 $$SUIT_Common-extensions,
 }
 
-SUIT_Components           = [ 1*12 SUIT_Component_Identifier ]
+SUIT_Components           = [ 1*16 SUIT_Component_Identifier ]
 
 ;REQUIRED to implement:
 suit-cose-hash-algs /= cose-alg-sha-256
@@ -130,7 +131,7 @@ SUIT_Shared_Commands //= (suit-directive-override-parameters,
 
 IndexArg /= uint
 IndexArg /= true
-IndexArg /= [+uint]
+IndexArg /= [ 1*16 uint ]
 
 
 SUIT_Directive_Try_Each_Argument_Shared = [

--- a/include/suit_types.h
+++ b/include/suit_types.h
@@ -20,9 +20,9 @@ extern "C" {
 /** The maximum number of bytestrings in a component ID. */
 #define SUIT_MAX_NUM_COMPONENT_ID_PARTS	    5
 /** The maximum number of components referenced in the manifest. */
-#define SUIT_MAX_NUM_COMPONENTS		    12
+#define SUIT_MAX_NUM_COMPONENTS		    16
 /** The maximum number of active components during processing dependency manifests. */
-#define SUIT_MAX_NUM_COMPONENT_PARAMS	    (SUIT_MAX_NUM_COMPONENTS * SUIT_MANIFEST_STACK_MAX_ENTRIES)
+#define SUIT_MAX_NUM_COMPONENT_PARAMS	    48
 /** The maximum number of integrated payloads in a single manifest. */
 #define SUIT_MAX_NUM_INTEGRATED_PAYLOADS    6
 /** The maximum number of arguments consumed by a single command. */

--- a/tests/unit/decoder/src/test_decode_manifest.c
+++ b/tests/unit/decoder/src/test_decode_manifest.c
@@ -355,7 +355,7 @@ static uint8_t cbor_envelope_with_single_null_component[] = {
 				0x80, /* array (0 elements) */
 };
 
-static uint8_t cbor_envelope_with_12_components[] = {
+static uint8_t cbor_envelope_with_16_components[] = {
 	0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
 	0xa2, /* map (2 elements) */
 
@@ -365,15 +365,27 @@ static uint8_t cbor_envelope_with_12_components[] = {
 			0x40, /* bytes(0) */
 
 	0x03, /* suit-manifest */
-	0x58, 0x2f, /* bytes(47) */
+	0x58, 0x3b, /* bytes(59) */
 	0xa3, /* map (3 elements) */
 	0x01, /* suit-manifest-version */ 0x01,
 	0x02, /* suit-manifest-sequence-number */ 0x10,
 	0x03, /* suit-common */
-		0x58, 0x27, /* bytes(39) */
+		0x58, 0x33, /* bytes(51) */
 		0xA1, /* map (1 element) */
 			0x02, /* suit-components */
-				0x8c, /* array (12 elements) */
+				0x90, /* array (16 elements) */
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
 				0x81, /* array (1 element) */
 					0x41, /* bytes(1) */
 					'M',
@@ -412,7 +424,7 @@ static uint8_t cbor_envelope_with_12_components[] = {
 					'M',
 };
 
-static uint8_t cbor_envelope_with_13_components[] = {
+static uint8_t cbor_envelope_with_17_components[] = {
 	0xd8, 0x6b, /* tag(107) : SUIT_Envelope */
 	0xa2, /* map (2 elements) */
 
@@ -422,15 +434,27 @@ static uint8_t cbor_envelope_with_13_components[] = {
 			0x40, /* bytes(0) */
 
 	0x03, /* suit-manifest */
-	0x58, 0x32, /* bytes(50) */
+	0x58, 0x3e, /* bytes(62) */
 	0xa3, /* map (3 elements) */
 	0x01, /* suit-manifest-version */ 0x01,
 	0x02, /* suit-manifest-sequence-number */ 0x10,
 	0x03, /* suit-common */
-		0x58, 0x2a, /* bytes(42) */
+		0x58, 0x36, /* bytes(54) */
 		0xA1, /* map (1 element) */
 			0x02, /* suit-components */
-				0x8d, /* array (13 elements) */
+				0x91, /* array (17 elements) */
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
+				0x81, /* array (1 element) */
+					0x41, /* bytes(1) */
+					'M',
 				0x81, /* array (1 element) */
 					0x41, /* bytes(1) */
 					'M',
@@ -709,7 +733,7 @@ void test_decode_manifest_max_components(void)
 {
 	int ret = SUIT_SUCCESS;
 
-	init_decode_envelope(cbor_envelope_with_12_components, sizeof(cbor_envelope_with_12_components));
+	init_decode_envelope(cbor_envelope_with_16_components, sizeof(cbor_envelope_with_16_components));
 	state.step = MANIFEST_DIGEST_VERIFIED;
 
 	ret = suit_decoder_decode_manifest(&state);
@@ -786,8 +810,8 @@ void test_decode_manifest_invalid_input_bytes(void)
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{
-			.envelope = cbor_envelope_with_13_components,
-			.envelope_size = sizeof(cbor_envelope_with_13_components),
+			.envelope = cbor_envelope_with_17_components,
+			.envelope_size = sizeof(cbor_envelope_with_17_components),
 			.exp_ret = ZCBOR_ERR_TO_SUIT_ERR(ZCBOR_ERR_PAYLOAD_NOT_CONSUMED),
 		},
 		{


### PR DESCRIPTION
Since the CDDL allows for setting 12 components, it is reasonable to allow for selecting all of them in a format of list.

Ref: NCSDK-NONE