### PR TITLE
cddl: Set the maximum number of sequences in try-each - FIX

### DIFF
--- a/cddl/manifest.cddl
+++ b/cddl/manifest.cddl
@@ -166,7 +166,7 @@ SUIT_Directive //= (suit-directive-copy,              SUIT_Rep_Policy)
 SUIT_Directive //= (suit-directive-invoke,            SUIT_Rep_Policy)
 
 SUIT_Directive_Try_Each_Argument = [
-  2*5 bstr .cbor SUIT_Command_Sequence,
+  2*32 bstr .cbor SUIT_Command_Sequence,
   ?nil
 ]
 


### PR DESCRIPTION
In the previous commit only for SUIT_Directive_Try_Each_Argument_Shared was increased and not for SUIT_Directive_Try_Each_Argument.